### PR TITLE
remove merge conflict marker from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,6 @@ integration = {
   }
 }
 ```
->>>>>>> main
 
 ## List of colorschemes
 


### PR DESCRIPTION
I noticed the README.md contained a merge conflict marker, e.g.

```
>>>>>>> main
```