### PR TITLE
Use correct diff from colorscheme

### DIFF
--- a/lua/catppuccino/core/mapper.lua
+++ b/lua/catppuccino/core/mapper.lua
@@ -139,7 +139,7 @@ local function get_base()
 		illuminatedCurWord = { bg = cpt.fg_gutter },
 		-- diff
 		diffAdded = { fg = cpt.diff.add },
-		diffRemoved = { fg = cpt.diff.remove },
+		diffRemoved = { fg = cpt.diff.delete },
 		diffChanged = { fg = cpt.diff.change },
 		diffOldFile = { fg = cpt.yellow },
 		diffNewFile = { fg = cpt.orange },


### PR DESCRIPTION
Hey! I saw that on fugitive Git panel the highlight wasn't working properly. After finding the highlight group I saw that the plugin was setting but checked and it seems that the color schemes were using a different word.

My change was to use `delete` instead of remove and not alter the colorschemes. If you want me to change it on the colorschemes, let me know :)

Love the theme! 