### PR TITLE
feat: nvim-cmp integration

### DIFF
--- a/lua/catppuccino/core/integrations/cmp.lua
+++ b/lua/catppuccino/core/integrations/cmp.lua
@@ -1,0 +1,15 @@
+local M = {}
+local util = require("catppuccino.utils.util")
+
+function M.get(cpt)
+	return {
+		CmpItemAbbr = { fg = util.darken(cpt.white, 0.56) },
+		CmpItemAbbrDeprecated = { fg = util.darken(cpt.white, 0.56), stlye = "strikethrough" },
+		CmpItemAbbrMatch = { fg = cpt.fg, style = "bold" },
+		CmpItemAbbrMatchFuzzy = { fg = cpt.fg, style = "bold" },
+		CmpItemKind = { fg = cpt.blue_br },
+		CmpItemMenu = { fg = cpt.fg },
+	}
+end
+
+return M


### PR DESCRIPTION
Add highlight groups for nvim-cmp's new feature floating window for
completion menus

Before:
![image](https://user-images.githubusercontent.com/29529436/136715978-24efa610-fd4b-45e7-89fc-1b72903a3f6c.png)

After:
![image](https://user-images.githubusercontent.com/29529436/136715998-95357675-c32e-461d-a237-b3e016b907b2.png)

How do you like it?