### PR TITLE
changing color for keywords for TreeSitter to catpuccin.4

### DIFF
--- a/lua/catppuccin/core/integrations/treesitter.lua
+++ b/lua/catppuccin/core/integrations/treesitter.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.get(cp)
-	local keywords = cp.catppuccin3
+	local keywords = cp.catppuccin4
 	return {
 		-- These groups are for the neovim tree-sitter highlights.
 		-- As of writing, tree-sitter support is a WIP, group names may change.


### PR DESCRIPTION
I am requesting this PR in order to update the keywords variable in the treesitter integration to change to catpuccin.4 (pink color).

In commit ff28039 the local variable `keywords` was introduced, unifying all the TSKeyword* highlights which is a great idea, however, I feel that using the purple tone color takes away part of the contrast which makes this theme great.

Reintroducing pink tones I believe maintains the contrast low while still providing a little pop to the colorscheme making it more appealing and also easier to read and differentiate.
Otherwise, it feels quite blue based and loses a bit of warmth.