### PR TITLE
setting all git add related highlights to green as standard

### DIFF
--- a/lua/catppuccin/core/integrations/gitgutter.lua
+++ b/lua/catppuccin/core/integrations/gitgutter.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.get(cp)
 	return {
-		GitGutterAdd = { fg = cp.blue },
+		GitGutterAdd = { fg = cp.green },
 		GitGutterChange = { fg = cp.yellow },
 		GitGutterDelete = { fg = cp.red },
 	}

--- a/lua/catppuccin/core/integrations/neogit.lua
+++ b/lua/catppuccin/core/integrations/neogit.lua
@@ -8,7 +8,7 @@ function M.get(cp)
 		NeogitHunkHeaderHighlight = { bg = cp.black4, fg = cp.blue },
 		NeogitDiffContextHighlight = { bg = cp.gray2, fg = cp.green },
 		NeogitDiffDeleteHighlight = { fg = cp.red, bg = cp.black2 },
-		NeogitDiffAddHighlight = { fg = cp.blue, bg = cp.black2 },
+		NeogitDiffAddHighlight = { fg = cp.green, bg = cp.black2 },
 	}
 end
 

--- a/lua/catppuccin/core/mapper.lua
+++ b/lua/catppuccin/core/mapper.lua
@@ -142,7 +142,7 @@ local function get_base()
 		illuminatedWord = { bg = cp.black4 },
 		illuminatedCurWord = { bg = cp.black4 },
 		-- diff
-		diffAdded = { fg = cp.blue },
+		diffAdded = { fg = cp.green },
 		diffRemoved = { fg = cp.red },
 		diffChanged = { fg = cp.yellow },
 		diffOldFile = { fg = cp.yellow },
@@ -150,7 +150,7 @@ local function get_base()
 		diffFile = { fg = cp.blue },
 		diffLine = { fg = cp.gray0 },
 		diffIndexLine = { fg = cp.pink },
-		DiffAdd = { fg = cp.blue, bg = cp.black2 }, -- diff mode: Added line |diff.txt|
+		DiffAdd = { fg = cp.green, bg = cp.black2 }, -- diff mode: Added line |diff.txt|
 		DiffChange = { fg = cp.yellow, bg = cp.black2 }, -- diff mode: Changed line |diff.txt|
 		DiffDelete = { fg = cp.red, bg = cp.black2 }, -- diff mode: Deleted line |diff.txt|
 		DiffText = { fg = cp.blue, bg = cp.black2 }, -- diff mode: Changed text within a changed line |diff.txt|


### PR DESCRIPTION
As per issue #75  , all add related highlights could be implemented as green color since it is fairly standard