### PR TITLE
fix: gitsigns transparent background

### DIFF
--- a/lua/catppuccin/core/integrations/gitsigns.lua
+++ b/lua/catppuccin/core/integrations/gitsigns.lua
@@ -2,9 +2,9 @@ local M = {}
 
 function M.get(cp)
 	return {
-		GitSignsAdd = { fg = cp.green, bg = cnf.transparency and cp.none or cp.black2 }, -- diff mode: Added line |diff.txt|
-		GitSignsChange = { fg = cp.yellow, bg = cnf.transparency and cp.none or cp.black2 }, -- diff mode: Changed line |diff.txt|
-		GitSignsDelete = { fg = cp.red, bg = cnf.transparency and cp.none or cp.black2 }, -- diff mode: Deleted line |diff.txt|
+		GitSignsAdd = { fg = cp.green, bg = cnf.transparent_background and cp.none or cp.black2 }, -- diff mode: Added line |diff.txt|
+		GitSignsChange = { fg = cp.yellow, bg = cnf.transparent_background and cp.none or cp.black2 }, -- diff mode: Changed line |diff.txt|
+		GitSignsDelete = { fg = cp.red, bg = cnf.transparent_background and cp.none or cp.black2 }, -- diff mode: Deleted line |diff.txt|
 	}
 end
 


### PR DESCRIPTION
It seems that a misnaming of `cnf.transparent_background` caused the background of `GitSigns*` colour groups to not be appropriately highlighted with a transparent background set.