### PR TITLE
fix(ts-rainbow): respect transparent_background

### DIFF
--- a/lua/catppuccin/core/integrations/ts_rainbow.lua
+++ b/lua/catppuccin/core/integrations/ts_rainbow.lua
@@ -1,14 +1,16 @@
 local M = {}
 
 function M.get(cp)
+	local transparent_background = require("catppuccin.config").options.transparent_background
+	local bg_highlight = transparent_background and nil or cp.black2
 	return {
-		rainbowcol1 = {bg = cp.black2, fg = cp.red},
-		rainbowcol2 = {bg = cp.black2, fg = cp.teal},
-		rainbowcol3 = {bg = cp.black2, fg = cp.yellow},
-		rainbowcol4 = {bg = cp.black2, fg = cp.blue},
-		rainbowcol5 = {bg = cp.black2, fg = cp.pink},
-		rainbowcol6 = {bg = cp.black2, fg = cp.flamingo},
-		rainbowcol7 = {bg = cp.black2, fg = cp.green},
+		rainbowcol1 = {bg = bg_highlight, fg = cp.red},
+		rainbowcol2 = {bg = bg_highlight, fg = cp.teal},
+		rainbowcol3 = {bg = bg_highlight, fg = cp.yellow},
+		rainbowcol4 = {bg = bg_highlight, fg = cp.blue},
+		rainbowcol5 = {bg = bg_highlight, fg = cp.pink},
+		rainbowcol6 = {bg = bg_highlight, fg = cp.flamingo},
+		rainbowcol7 = {bg = bg_highlight, fg = cp.green},
 	}
 end
 


### PR DESCRIPTION
When setting nvim-ts-rainbow highlight groups, do not set a background highlight if  is