### PR TITLE
Improve background colors in neogit integration

### DIFF
--- a/lua/catppuccin/core/integrations/neogit.lua
+++ b/lua/catppuccin/core/integrations/neogit.lua
@@ -5,10 +5,10 @@ function M.get(cp)
 		NeogitBranch = { fg = cp.pink },
 		NeogitRemote = { fg = cp.pink },
 		NeogitHunkHeader = { bg = cp.blue, fg = cp.white },
-		NeogitHunkHeaderHighlight = { bg = cp.black4, fg = cp.blue },
-		NeogitDiffContextHighlight = { bg = cp.gray2, fg = cp.green },
-		NeogitDiffDeleteHighlight = { fg = cp.red, bg = cp.black2 },
-		NeogitDiffAddHighlight = { fg = cp.green, bg = cp.black2 },
+		NeogitHunkHeaderHighlight = { bg = cp.black2, fg = cp.blue },
+		NeogitDiffContextHighlight = { bg = cp.black1, fg = cp.gray2 },
+		NeogitDiffDeleteHighlight = { bg = cp.black1, fg = cp.red },
+		NeogitDiffAddHighlight = { bg = cp.black1, fg = cp.green },
 	}
 end
 


### PR DESCRIPTION
Change background color in neogit integration. Use a slightly more light color than the background instead of a very light color. Headers are more light, but only slightly.

Added and Removed lines also gets background highlight matching to make it more obvious which hunk you are acting on.

See videos for changes.

https://user-images.githubusercontent.com/1599/149591064-d9a403a8-5144-420a-98e6-47871372079e.mp4


https://user-images.githubusercontent.com/1599/149591066-061bb2e9-5039-48d4-ac1c-1b36f851bb7a.mp4

References #75.