### PR TITLE
Improve legibility of right side of lightline.

### DIFF
--- a/lua/lightline/colorscheme/catppuccin.lua
+++ b/lua/lightline/colorscheme/catppuccin.lua
@@ -4,7 +4,7 @@ local catppuccin = {}
 catppuccin.normal = {
 	left = { { cp.black1, cp.blue }, { cp.blue, cp.black2 } },
 	middle = { { cp.blue, cp.black4 } },
-	right = { { cp.black0, cp.black2 }, { cp.blue, cp.black2 } },
+	right = { { cp.gray0, cp.black2 }, { cp.blue, cp.black3 } },
 	error = { { cp.black1, cp.red } },
 	warning = { { cp.black1, cp.yellow } },
 }


### PR DESCRIPTION
This improves the legibility of the right side of lightline. The rightmost section matches an existing color combination in multiple other components. The second-to-rightmost component background has a small shade lightening to distinguish it from the rightmost component.

Currently on `main`:
![Screen Shot 2022-01-20 at 2 54 48 PM](https://user-images.githubusercontent.com/8517/150437363-0b02ecc3-288f-4351-bc62-cf36e62d9e1a.png)

With these changes:
![Screen Shot 2022-01-20 at 2 54 22 PM](https://user-images.githubusercontent.com/8517/150437373-9df8a2e0-20a1-4244-a30a-fc7bc301da60.png)