### PR TITLE
fix: nvimtree integration transparent panel

### DIFF
--- a/lua/catppuccin/core/integrations/nvimtree.lua
+++ b/lua/catppuccin/core/integrations/nvimtree.lua
@@ -2,17 +2,18 @@ local M = {}
 
 function M.get(cp)
 	local config = require("catppuccin.config").options
+	local nvimtree = config.integrations.nvimtree
 
 	local root_dir_color = cp.pink
 
-	if config.integrations.nvimtree.show_root then
+	if nvimtree.show_root then
 		root_dir_color = cp.blue
 	end
 
 	return {
 		NvimTreeFolderName = { fg = cp.blue },
 		NvimTreeFolderIcon = { fg = cp.blue },
-		NvimTreeNormal = { fg = cp.white, bg = cp.black1 },
+		NvimTreeNormal = { fg = cp.white, bg = nvimtree.transparent_panel and "NONE" or cp.black1 },
 		NvimTreeOpenedFolderName = { fg = cp.blue },
 		NvimTreeEmptyFolderName = { fg = cp.blue },
 		NvimTreeIndentMarker = { fg = cp.gray0 },


### PR DESCRIPTION
Seems like a typo was causing this feature (#98) to not work as expected