### PR TITLE
💄Lualine theme: Improve horizontal split visibility

### DIFF
--- a/lua/lualine/themes/catppuccin.lua
+++ b/lua/lualine/themes/catppuccin.lua
@@ -28,9 +28,9 @@ catppuccin.replace = {
 }
 
 catppuccin.inactive = {
-	a = { bg = cp.black2, fg = cp.blue },
-	b = { bg = cp.black2, fg = cp.black4, gui = "bold" },
-	c = { bg = cp.black2, fg = cp.gray0 },
+	a = { bg = cp.black1, fg = cp.blue },
+	b = { bg = cp.black1, fg = cp.black4, gui = "bold" },
+	c = { bg = cp.black1, fg = cp.gray0 },
 }
 
 return catppuccin


### PR DESCRIPTION
This PR improves the visibility of horizontal splits when using the supplied lualine theme.

Here's the "before" (how it is right now):

<img width="1011" alt="Schermata 2022-01-25 alle 08 56 45" src="https://user-images.githubusercontent.com/131911/150935724-20295412-c9b9-49ff-902d-f7004a8e3254.png">

It's really hard to tell that there is an horizontal split here, right?

And here's the "after" (how it is in the PR):

<img width="657" alt="Schermata 2022-01-25 alle 08 57 26" src="https://user-images.githubusercontent.com/131911/150935857-34ba6e4c-63db-45db-b988-45d7699b2c8e.png">

It looks much clearer, IMHO.
