### PR TITLE
fix: Handle nil winid values in feline integration

### DIFF
--- a/lua/catppuccin/core/integrations/feline.lua
+++ b/lua/catppuccin/core/integrations/feline.lua
@@ -62,6 +62,15 @@ local mode_colors = {
 
 local shortline = false
 
+local function is_enabled(is_shortline, winid, min_width)
+	if is_shortline then
+		return true
+	end
+
+	winid = winid or 0
+	return vim.api.nvim_win_get_width(winid) > min_width
+end
+
 -- Initialize the components table
 local components = {
 	active = {},

--- a/lua/catppuccin/core/integrations/feline.lua
+++ b/lua/catppuccin/core/integrations/feline.lua
@@ -23,7 +23,7 @@ local assets = {
 	slant_right_2 = "",
 	slant_right_2_thin = "",
 	chubby_dot = "●",
-	slim_dot = '•',
+	slim_dot = "•",
 }
 
 local clrs = require("catppuccin.core.color_palette")
@@ -77,7 +77,7 @@ local invi_sep = {
 	str = " ",
 	hl = {
 		fg = sett.bkg,
-		bg = sett.bkg
+		bg = sett.bkg,
 	},
 }
 
@@ -85,16 +85,18 @@ local invi_sep = {
 local function any_git_changes()
 	local gst = b.gitsigns_status_dict -- git stats
 	if gst then
-		if gst["added"] and gst["added"] > 0 or gst["removed"] and gst["removed"] > 0 or gst["changed"] and gst["changed"] > 0 then
+		if
+			gst["added"] and gst["added"] > 0
+			or gst["removed"] and gst["removed"] > 0
+			or gst["changed"] and gst["changed"] > 0
+		then
 			return true
 		end
 	end
 	return false
 end
 
-
 -- #################### STATUSLINE ->
-
 
 -- ######## Left
 
@@ -103,7 +105,7 @@ local vi_mode_hl = function()
 	return {
 		fg = sett.bkg,
 		bg = mode_colors[vim.fn.mode()][2],
-		style = "bold"
+		style = "bold",
 	}
 end
 
@@ -146,12 +148,12 @@ components.active[1][4] = {
 	hl = function()
 		return {
 			fg = mode_colors[vim.fn.mode()][2],
-			bg = sett.bkg
+			bg = sett.bkg,
 		}
 	end,
 	enabled = function()
 		return not any_git_changes()
-	end
+	end,
 }
 
 -- enable if git diffs are available
@@ -160,12 +162,12 @@ components.active[1][5] = {
 	hl = function()
 		return {
 			fg = mode_colors[vim.fn.mode()][2],
-			bg = sett.diffs
+			bg = sett.diffs,
 		}
 	end,
 	enabled = function()
 		return any_git_changes()
-	end
+	end,
 }
 -- Current vi mode ------>
 
@@ -205,7 +207,7 @@ components.active[1][9] = {
 	},
 	enabled = function()
 		return any_git_changes()
-	end
+	end,
 }
 -- Diffs ------>
 
@@ -230,7 +232,7 @@ components.active[1][10] = {
 	-- end,
 	hl = {
 		fg = sett.extras,
-		bg = sett.bkg
+		bg = sett.bkg,
 	},
 	left_sep = invi_sep,
 }
@@ -243,7 +245,7 @@ components.active[1][11] = {
 	-- end,
 	hl = {
 		fg = sett.extras,
-		bg = sett.bkg
+		bg = sett.bkg,
 	},
 	left_sep = invi_sep,
 }
@@ -290,7 +292,7 @@ components.active[2][1] = {
 	end,
 	hl = {
 		fg = clrs.rosewater,
-		bg = sett.bkg
+		bg = sett.bkg,
 	},
 }
 
@@ -356,7 +358,7 @@ components.active[3][1] = {
 	end,
 	hl = {
 		fg = sett.extras,
-		bg = sett.bkg
+		bg = sett.bkg,
 	},
 	icon = "   ",
 	left_sep = invi_sep,
@@ -373,7 +375,7 @@ components.active[3][2] = {
 	end,
 	hl = {
 		fg = sett.extras,
-		bg = sett.bkg
+		bg = sett.bkg,
 	},
 	right_sep = invi_sep,
 }

--- a/lua/catppuccin/core/integrations/feline.lua
+++ b/lua/catppuccin/core/integrations/feline.lua
@@ -296,9 +296,7 @@ components.active[2][1] = {
 
 		return ""
 	end,
-	enabled = shortline or function(winid)
-		return vim.api.nvim_win_get_width(winid) > 80
-	end,
+	enabled = is_enabled(shortline, winid, 80),
 	hl = {
 		fg = clrs.rosewater,
 		bg = sett.bkg,
@@ -362,9 +360,7 @@ components.active[2][5] = {
 
 components.active[3][1] = {
 	provider = "git_branch",
-	enabled = shortline or function(winid)
-		return vim.api.nvim_win_get_width(winid) > 70
-	end,
+	enabled = is_enabled(shortline, winid, 70),
 	hl = {
 		fg = sett.extras,
 		bg = sett.bkg,
@@ -400,9 +396,7 @@ components.active[3][3] = {
 		end
 		return " " .. icon .. " " .. filename .. " "
 	end,
-	enabled = shortline or function(winid)
-		return vim.api.nvim_win_get_width(winid) > 70
-	end,
+	enabled = is_enabled(shortline, winid, 70),
 	hl = {
 		fg = sett.bkg,
 		bg = sett.curr_file,
@@ -422,9 +416,7 @@ components.active[3][4] = {
 		return "  " .. dir_name .. " "
 	end,
 
-	enabled = shortline or function(winid)
-		return vim.api.nvim_win_get_width(winid) > 80
-	end,
+	enabled = is_enabled(shortline, winid, 80),
 
 	hl = {
 		fg = sett.bkg,


### PR DESCRIPTION
Attempting to use the feline integration resulted in an error message when `winid` was `nil`. This pr contains the following changes:

* Applying stylua formatting
* Added helper function `is_enabled` that ensures winid is always a Lua number
* Replacing blocks setting the `enabled` attribute with calls to the new `is_enabled` helper function.

Let me know if the styling or naming should be tweaked.