### PR TITLE
docs: Point towards fork 'tami5/lspsaga' instead of 'glepnir/lspsaga'

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This port of Catppuccin is special because it was the first one and the one that
     -   [Feline](https://github.com/feline-nvim/feline.nvim)
     -   [Lualine](https://github.com/hoob3rt/lualine.nvim)
     -   [Nvim-cmp](https://github.com/hrsh7th/nvim-cmp)
-    -   [LSP Saga](https://github.com/glepnir/lspsaga.nvim)
+    -   [LSP Saga](https://github.com/tami5/lspsaga.nvim)
     -   [Git signs](https://github.com/lewis6991/gitsigns.nvim)
     -   [Indent Blankline](https://github.com/lukas-reineke/indent-blankline.nvim)
     -   [Trouble](https://github.com/folke/trouble.nvim)


### PR DESCRIPTION
As explained in #126, `'glepnir/lspsaga'` does not seem to be maintained anymore with its last commit over 12 months ago and many bugs. `'tami5/lspsaga'` is a well-maintained fork with exactly the same settings and config that people should be pointed towards.

Closes #126 