### PR TITLE
tweaked telescope colors and added custom highlights

### DIFF
--- a/lua/catppuccin/config.lua
+++ b/lua/catppuccin/config.lua
@@ -70,6 +70,7 @@ config.options = {
 		telekasten = true,
 		symbols_outline = true,
 	},
+  custom_highlights = {},
 }
 
 function config.set_options(opts)

--- a/lua/catppuccin/core/integrations/telescope.lua
+++ b/lua/catppuccin/core/integrations/telescope.lua
@@ -6,6 +6,16 @@ function M.get(cp)
 		TelescopeSelectionCaret = { fg = cp.flamingo },
 		TelescopeSelection = { fg = cp.text, bg = cp.surface0, style = "bold" },
 		TelescopeMatching = { fg = cp.blue },
+    TelescopePromptPrefix = { bg = cp.crust },
+    TelescopePromptNormal = { bg = cp.crust},
+    TelescopeResultsNormal = { bg = cp.mantle},
+    TelescopePreviewNormal = { bg = cp.crust },
+    TelescopePromptBorder = { bg = cp.crust, fg = cp.crust },
+    TelescopeResultsBorder = { bg = cp.mantle, fg = cp.crust },
+    TelescopePreviewBorder = { bg = cp.crust, fg = cp.crust },
+    TelescopePromptTitle = { fg = cp.crust },
+    TelescopeResultsTitle = { fg = cp.text },
+    TelescopePreviewTitle = { fg = cp.crust },
 	}
 end
 

--- a/lua/catppuccin/utils/util.lua
+++ b/lua/catppuccin/utils/util.lua
@@ -147,12 +147,16 @@ function util.load(theme)
 	if vim.fn.exists("syntax_on") then
 		vim.cmd("syntax reset")
 	end
+  local custom_highlights = require("catppuccin.config").options.custom_highlights
+
 
 	g.colors_name = "catppuccin"
+  
 
 	util.properties(theme.properties)
 	util.syntax(theme.base)
 	util.syntax(theme.integrations)
+  util.syntax(custom_highlights)
 
 	if require("catppuccin.config").options["term_colors"] then
 		util.terminal(theme.terminal)


### PR DESCRIPTION
It bothered me that the telescope popup blended in with the background, especially if you remove the borders. In addition, I've added the ability to add custom highlights in the config, in case similar issues to this exist.