### PR TITLE
use autocmd event instead of after_loading hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,20 @@ catppuccin.before_loading = function ()
 end
 ```
 
+#### Autocmd
+
+Instead of `after_loading` hook, you can use autocmd event like this:
+
+```lua
+vim.api.nvim_create_autocmd("User", {
+    pattern = "CatppuccinLoaded",
+    callback = function()
+        local colors = require("catppuccin.api.colors").get_colors()
+        -- do something with colors
+    end
+})
+```
+
 ## 💝 Thanks to
 
 -   [Pocco81](https://github.com/Pocco81)

--- a/lua/catppuccin/core/integrations/lightspeed.lua
+++ b/lua/catppuccin/core/integrations/lightspeed.lua
@@ -13,19 +13,14 @@ end
 function M.get(cp)
 
 	if not get_prepared() then
-		local catppuccin = require("catppuccin")
-		if catppuccin.after_loading ~= nil then
-			local callback = catppuccin.after_loading
-			catppuccin.after_loading = function ()
-				callback()
-				require'lightspeed'.init_highlight()
+		set_prepared(vim.api.nvim_create_autocmd("User", {
+			pattern = "CatppuccinLoaded",
+			callback = function ()
+				if pcall(require, "lightspeed") then
+					require("lightspeed").init_highlight()
+				end
 			end
-		else
-			catppuccin.after_loading = function ()
-				require'lightspeed'.init_highlight()
-			end
-		end
-		set_prepared(true)
+		}))
 	end
 
 	return {

--- a/lua/catppuccin/main.lua
+++ b/lua/catppuccin/main.lua
@@ -21,6 +21,8 @@ local function load()
 	if catppuccin.after_loading ~= nil then
 		catppuccin.after_loading()
 	end
+
+	vim.api.nvim_exec_autocmds("User", { pattern = "CatppuccinLoaded" })
 end
 
 function M.main(option)


### PR DESCRIPTION
When we have a lot of 3rd party plugins, everyone will do a hook and wrap what's already there, it's too complicated.

why not use events?