### PR TITLE
Support overriding colors using vim.g.catppuccin_override_colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,18 @@ local colors = require'catppuccin.api.colors'.get_colors() -- fetch colors with 
 catppuccin.remap({ Comment = { fg = colors.flamingo }, })
 ```
 
+#### Overwriting colors
+
+Colors can be overwritten using `vim.g.catppucin_override_colors`:
+
+```lua
+vim.g.catppuccin_override_colors = {
+  base = "#ff0000",
+  mantle = "#242424",
+  crust = "#474747",
+}
+```
+
 #### Hooks
 
 Use them to execute code at certain events. These are the ones available:

--- a/lua/catppuccin/config.lua
+++ b/lua/catppuccin/config.lua
@@ -71,6 +71,7 @@ config.options = {
 		telekasten = true,
 		symbols_outline = true,
 	},
+	color_overrides = {}
 }
 
 function config.set_options(opts)

--- a/lua/catppuccin/core/palettes/init.lua
+++ b/lua/catppuccin/core/palettes/init.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local cnf = require("catppuccin.config").options
+
 function M.get_palette()
 	local flvr = vim.g.catppuccin_flavour
 
@@ -8,16 +10,20 @@ function M.get_palette()
 		palette = require("catppuccin.core.palettes." .. flvr)
 	end
 
-	if type(vim.g.catppuccin_override_colors) == "table" then
-		for k, v in pairs(vim.g.catppuccin_override_colors) do
-			if palette[k] then
-				palette[k] = v
-			else
-				vim.api.nvim_echo(
-					{ { 'Warning: "' .. k .. '" is not a valid catppucin palette color.', "WarningMsg" } },
-					true,
-					{}
-				)
+	if type(cnf.color_overrides) == "table" then
+		for _, pal in pairs({"all", flvr}) do
+			if cnf.color_overrides[pal] ~= nil then
+				for k, v in pairs(cnf.color_overrides[pal]) do
+					if palette[k] then
+						palette[k] = v
+					else
+						vim.api.nvim_echo(
+							{ { 'Warning: "' .. k .. '" is not a valid catppucin palette color.', "WarningMsg" } },
+							true,
+							{}
+						)
+					end
+				end
 			end
 		end
 	end

--- a/lua/catppuccin/core/palettes/init.lua
+++ b/lua/catppuccin/core/palettes/init.lua
@@ -12,6 +12,12 @@ function M.get_palette()
 		for k, v in pairs(vim.g.catppuccin_override_colors) do
 			if palette[k] then
 				palette[k] = v
+			else
+				vim.api.nvim_echo(
+					{ { 'Warning: "' .. k .. '" is not a valid catppucin palette color.', "WarningMsg" } },
+					true,
+					{}
+				)
 			end
 		end
 	end

--- a/lua/catppuccin/core/palettes/init.lua
+++ b/lua/catppuccin/core/palettes/init.lua
@@ -3,10 +3,20 @@ local M = {}
 function M.get_palette()
 	local flvr = vim.g.catppuccin_flavour
 
+	local palette = require("catppuccin.core.palettes.mocha")
 	if flvr == "mocha" or flvr == "latte" or flvr == "macchiato" or flvr == "frappe" then
-		return require("catppuccin.core.palettes." .. flvr)
+		palette = require("catppuccin.core.palettes." .. flvr)
 	end
-	return require("catppuccin.core.palettes.mocha")
+
+	if type(vim.g.catppuccin_override_colors) == "table" then
+		for k, v in pairs(vim.g.catppuccin_override_colors) do
+			if palette[k] then
+				palette[k] = v
+			end
+		end
+	end
+
+	return palette
 end
 
 return M


### PR DESCRIPTION
This PR proposes a simple way to override the palette colors by setting the global variable `vim.g.catppucin_override_colors`.

Usage:
```lua
  vim.g.catppuccin_flavour = "mocha"
  vim.g.catppuccin_override_colors = {
    base = "#ff0000"
  }
  vim.cmd [[colorscheme catppuccin]]
```