### PR TITLE
Add explicit support for 'mini.nvim'

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This port of Catppuccin is special because it was the first one and the one that
     -   [Telekasten](https://github.com/renerocksai/telekasten.nvim)
     -   [Notify](https://github.com/rcarriga/nvim-notify)
     -   [Symbols-Outline](https://github.com/simrat39/symbols-outline.nvim)
+    -   [Mini.nvim](https://github.com/echasnovski/mini.nvim)
 
 ## Usage
 
@@ -149,6 +150,7 @@ integrations = {
 	notify = true,
 	telekasten = true,
 	symbols_outline = true,
+	mini = false,
 }
 ```
 

--- a/lua/catppuccin/core/integrations/mini.lua
+++ b/lua/catppuccin/core/integrations/mini.lua
@@ -1,0 +1,62 @@
+local M = {}
+
+function M.get(cp)
+	local transparent_background = require("catppuccin.config").options.transparent_background
+	local bg_highlight = transparent_background and "NONE" or cp.base
+
+	local inactive_bg = transparent_background and "NONE" or cp.mantle
+
+	return {
+		MiniCompletionActiveParameter = { style = "underline" },
+
+		MiniCursorword = { style = "underline" },
+		MiniCursorwordCurrent = { style = "underline" },
+
+		MiniIndentscopeSymbol = { fg = cp.text },
+		MiniIndentscopePrefix = { style = "nocombine" }, -- Make it invisible
+
+		MiniJump = { fg = cp.overlay2, bg = cp.pink },
+
+		MiniJump2dSpot = { bg = cp.base, fg = cp.peach, style = "bold,underline" },
+
+		MiniStarterCurrent = {},
+		MiniStarterFooter = { fg = cp.yellow, style = "italic" },
+		MiniStarterHeader = { fg = cp.blue },
+		MiniStarterInactive = { fg = cp.surface2, style = cnf.styles.comments },
+		MiniStarterItem = { fg = cp.text },
+		MiniStarterItemBullet = { fg = cp.blue },
+		MiniStarterItemPrefix = { fg = cp.pink },
+		MiniStarterSection = { fg = cp.flamingo },
+		MiniStarterQuery = { fg = cp.green },
+
+		MiniStatuslineDevinfo = { fg = cp.subtext1, bg = cp.surface1 },
+		MiniStatuslineFileinfo = { fg = cp.subtext1, bg = cp.surface1 },
+		MiniStatuslineFilename = { fg = cp.text, bg = cp.mantle },
+		MiniStatuslineInactive = { fg = cp.blue, bg = cp.mantle },
+		MiniStatuslineModeCommand = { fg = cp.base, bg = cp.peach, style = "bold" },
+		MiniStatuslineModeInsert = { fg = cp.base, bg = cp.green, style = "bold" },
+		MiniStatuslineModeNormal = { fg = cp.mantle, bg = cp.blue, style = "bold" },
+		MiniStatuslineModeOther = { fg = cp.base, bg = cp.teal, style = "bold" },
+		MiniStatuslineModeReplace = { fg = cp.base, bg = cp.red, style = "bold" },
+		MiniStatuslineModeVisual = { fg = cp.base, bg = cp.mauve, style = "bold" },
+
+		MiniSurround = { bg = cp.pink, fg = cp.surface1 },
+
+		MiniTablineCurrent = { fg = cp.text, bg = cp.base, style = "bold,italic" },
+		MiniTablineFill = { bg = bg_highlight },
+		MiniTablineHidden = { fg = cp.text, bg = inactive_bg },
+		MiniTablineModifiedCurrent = { fg = cp.base, bg = cp.text, style = "bold,italic" },
+		MiniTablineModifiedHidden = { fg = inactive_bg, bg = cp.text },
+		MiniTablineModifiedVisible = { fg = cp.surface1, bg = cp.subtext1 },
+		MiniTablineTabpagesection = { fg = cp.surface1, bg = cp.base },
+		MiniTablineVisible = { fg = cp.subtext1, bg = cp.surface1 },
+
+		MiniTestEmphasis = { style = "bold" },
+		MiniTestFail = { fg = cp.red, style = "bold" },
+		MiniTestPass = { fg = cp.green, style = "bold" },
+
+		MiniTrailspace = { bg = cp.red },
+	}
+end
+
+return M


### PR DESCRIPTION
Hi! I would like to add explicit support for [mini.nvim](https://github.com/echasnovski/mini.nvim).

Basic choices are taken from either highlight groups to which 'mini.nvim' makes default links or from analogous plugins.

Differences from default linked groups:
- 'mini.indentscope' is based on 'indent_blankline.lua'.
- 'mini.jump' is based on 'vim_sneak.lua'.
- 'mini.jump2d' is based on 'hop.lua'.
- 'mini.starter' is based on 'dashboard.lua', 'which_key.lua', and personal choices:
    - `MiniStarterInactive` is same as comments.
    - `MiniStarterItemBullet` is blue as borders.
    - `MiniStarterQuery` is green to be opposite of pink item's prefix.
    - `MiniStarterSection` is flamingo to be visible.
- 'mini.statusline' is based on 'lualine/themes/catppuccin.lua' and personal choices:
    - `MiniStatuslineDevinfo` and `MiniStatuslineFileinfo` are "slightly different text".
    - `MiniStatuslineModeOther` has teal background so that be separable from other modes.
- 'mini.tabline' is based on 'bufferline.lua':
    - `MiniTablineVisible` is "slightly different text".
    - `MiniTablineModified*` groups have inverted `fg` and `bg` of their counterparts.
- 'mini.test' has red for fail and green for pass.
- 'mini.trailspace' has group with red background to draw attention.

Before:

https://user-images.githubusercontent.com/24854248/177376092-2e9836aa-c845-4781-b79a-fbdf4f3175a8.mp4

After:

https://user-images.githubusercontent.com/24854248/177376123-c61ea18e-39b8-4a42-95b1-8811297f2b35.mp4
