### PR TITLE
Add config for dimming inactive windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Plugin 'catppuccin/nvim', {'name': 'catppuccin'}
 There are already some sane defaults that you may like, however you can change them to match your taste. These are the defaults:
 
 ```lua
+dim_inactive = false,
 transparent_background = false,
 term_colors = false,
 styles = {
@@ -213,6 +214,8 @@ This settings are unrelated to any group and are independent.
 
 -   `transparent_background`: (Boolean) if true, disables setting the background color.
 -   `term_colors`: (Boolean) if true, sets terminal colors (e.g. `g:terminal_color_0`).
+-   `dim_inactive`: (Boolean) if true, dims the background color of inactive
+    window or buffer or split.
 
 #### Styles
 

--- a/lua/catppuccin/config.lua
+++ b/lua/catppuccin/config.lua
@@ -2,6 +2,7 @@
 local config = {}
 
 config.options = {
+	dim_inactive = false,
 	transparent_background = false,
 	term_colors = false,
 	styles = {
@@ -35,7 +36,7 @@ config.options = {
 				information = "underline",
 			},
 		},
-        coc_nvim = false,
+		coc_nvim = false,
 		lsp_trouble = false,
 		cmp = true,
 		lsp_saga = false,

--- a/lua/catppuccin/core/mapper.lua
+++ b/lua/catppuccin/core/mapper.lua
@@ -52,7 +52,13 @@ local function get_base()
 		MoreMsg = { fg = cp.blue }, -- |more-prompt|
 		NonText = { fg = cp.overlay0 }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
 		Normal = { fg = cp.text, bg = cnf.transparent_background and cp.none or cp.base }, -- normal text
-		NormalNC = { fg = cp.text, bg = cnf.transparent_background and cp.none or cp.base }, -- normal text in non-current windows
+		NormalNC = {
+			fg = cp.text,
+			bg = (cnf.transparent_background and cnf.dim_inactive and cp.dim)
+				or (cnf.dim_inactive and cp.dim)
+				or (cnf.transparent_background and cp.none)
+				or cp.base,
+		}, -- normal text in non-current windows
 		NormalSB = { fg = cp.text, bg = cp.crust }, -- normal text in non-current windows
 		NormalFloat = { fg = cp.text, bg = cp.mantle }, -- Normal text in floating windows.
 		FloatBorder = { fg = cp.blue },

--- a/lua/catppuccin/core/palettes/frappe.lua
+++ b/lua/catppuccin/core/palettes/frappe.lua
@@ -32,6 +32,7 @@ local color_palette = {
 	base = "#303446",
 	mantle = "#292C3C",
 	crust = "#232634",
+	dim = "#444858",
 }
 
 return color_palette

--- a/lua/catppuccin/core/palettes/latte.lua
+++ b/lua/catppuccin/core/palettes/latte.lua
@@ -29,9 +29,10 @@ local color_palette = {
 	surface1 = "#BCC0CC",
 	surface0 = "#CCD0DA",
 
+	base = "#EFF1F5",
 	crust = "#DCE0E8",
 	mantle = "#E6E9EF",
-	base = "#EFF1F5",
+	dim = "#D7D8DC",
 }
 
 return color_palette

--- a/lua/catppuccin/core/palettes/macchiato.lua
+++ b/lua/catppuccin/core/palettes/macchiato.lua
@@ -32,6 +32,7 @@ local color_palette = {
 	base = "#24273A",
 	mantle = "#1E2030",
 	crust = "#181926",
+	dim = "#393C4D",
 }
 
 return color_palette

--- a/lua/catppuccin/core/palettes/mocha.lua
+++ b/lua/catppuccin/core/palettes/mocha.lua
@@ -32,6 +32,7 @@ local color_palette = {
 	base = "#1E1E2E",
 	mantle = "#181825",
 	crust = "#11111B",
+	dim = "#343442",
 }
 
 return color_palette


### PR DESCRIPTION
Summary
----
This adds a (bool) configuration option `dim_inactive` (default false) to allow users to dim inactive windows/buffers/splits.

Related Issue(s)
----
<https://github.com/catppuccin/nvim/issues/89>

Notes
----
I tested the colors locally and they seem to indicate pretty clearly which window is active and which is inactive. I basically used hex tool and picked the next dimmer color from `base`.