### PR TITLE
docs(README): fix coc tab spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ integrations = {
 			information = "underline",
 		},
 	},
-    coc_nvim = false,
+	coc_nvim = false,
 	lsp_trouble = false,
 	cmp = true,
 	lsp_saga = false,


### PR DESCRIPTION
There's a small misalignment that can throw some people off (myself included). This PR uses tab instead of spaces to indent coc.nvim config

<img width="270" alt="image" src="https://user-images.githubusercontent.com/3452930/178126321-77ab1da3-c2c3-42ca-827f-28626edebd13.png">
