### PR TITLE
fix(syntax): Fix missing `,` in config.lua

### DIFF
--- a/lua/catppuccin/config.lua
+++ b/lua/catppuccin/config.lua
@@ -35,7 +35,7 @@ config.options = {
 				information = "underline",
 			},
 		},
-        coc_nvim = false,
+		coc_nvim = false,
 		lsp_trouble = false,
 		cmp = true,
 		lsp_saga = false,
@@ -71,8 +71,8 @@ config.options = {
 		telekasten = true,
 		symbols_outline = true,
 	},
-	color_overrides = {}
-  custom_highlights = {},
+	color_overrides = {},
+	custom_highlights = {},
 }
 
 function config.set_options(opts)


### PR DESCRIPTION
Missing comma in config causing catppuccin to fail to load