### PR TITLE
fix(highlight): Fix blend option

### DIFF
--- a/lua/catppuccin/core/integrations/indent_blankline.lua
+++ b/lua/catppuccin/core/integrations/indent_blankline.lua
@@ -8,12 +8,12 @@ function M.get(cp)
 	}
 
 	if cnf.integrations.indent_blankline.colored_indent_levels then
-		hi["IndentBlanklineIndent6"] = {blend = "nocombine", fg = cp.yellow}
-		hi["IndentBlanklineIndent5"] = {blend = "nocombine", fg = cp.red}
-		hi["IndentBlanklineIndent4"] = {blend = "nocombine", fg = cp.teal}
-		hi["IndentBlanklineIndent3"] = {blend = "nocombine", fg = cp.peach}
-		hi["IndentBlanklineIndent2"] = {blend = "nocombine", fg = cp.blue}
-		hi["IndentBlanklineIndent1"] = {blend = "nocombine", fg = cp.pink}
+		hi["IndentBlanklineIndent6"] = {blend = 0, fg = cp.yellow}
+		hi["IndentBlanklineIndent5"] = {blend = 0, fg = cp.red}
+		hi["IndentBlanklineIndent4"] = {blend = 0, fg = cp.teal}
+		hi["IndentBlanklineIndent3"] = {blend = 0, fg = cp.peach}
+		hi["IndentBlanklineIndent2"] = {blend = 0, fg = cp.blue}
+		hi["IndentBlanklineIndent1"] = {blend = 0, fg = cp.pink}
 	end
 
 	return hi


### PR DESCRIPTION
I downloaded neovim 0.5 appimage and blend has always been integer value. No idea why is `nocombine` from `cterm` is here

Closes https://github.com/catppuccin/nvim/issues/173