### PR TITLE
fix(g.colors_name): Set colorscheme name

### DIFF
--- a/lua/catppuccin/utils/util.lua
+++ b/lua/catppuccin/utils/util.lua
@@ -82,6 +82,7 @@ function util.load(theme)
 	if vim.fn.exists("syntax_on") then
 		vim.cmd("syntax reset")
 	end
+	g.colors_name = "catppuccin"
 	local custom_highlights = require("catppuccin.config").options.custom_highlights
 
 	util.properties(theme.properties)


### PR DESCRIPTION
Fix:

https://github.com/catppuccin/nvim/commit/482de1a974f4405a70a7802341c9ada463d6a856

- `:colorscheme` no longer return catppuccin

- lualine `theme = "auto"` doesn't work