### PR TITLE
refactor(performance): Improve nvim_set_hl

### DIFF
--- a/lua/catppuccin/core/integrations/bufferline.lua
+++ b/lua/catppuccin/core/integrations/bufferline.lua
@@ -14,7 +14,7 @@ function M.get(cp)
 		BufferLineFill = { bg = bg_highlight },
 		BufferLineBackcrust = { fg = cp.text, bg = inactive_bg }, -- others
 		BufferLineBufferVisible = { fg = cp.surface1, bg = inactive_bg },
-		BufferLineBufferSelected = { fg = cp.text, bg = cp.base, style = "bold,italic" }, -- current
+		BufferLineBufferSelected = { fg = cp.text, bg = cp.base, style = { "bold", "italic" } }, -- current
 		BufferLineTab = { fg = cp.surface1, bg = cp.base },
 		BufferLineTabSelected = { fg = cp.red, bg = cp.blue },
 		BufferLineTabClose = { fg = cp.red, bg = inactive_bg },

--- a/lua/catppuccin/core/integrations/hop.lua
+++ b/lua/catppuccin/core/integrations/hop.lua
@@ -2,9 +2,9 @@ local M = {}
 
 function M.get(cp)
 	return {
-		HopNextKey = { bg = cp.base, fg = cp.peach, style = "bold,underline" },
+		HopNextKey = { bg = cp.base, fg = cp.peach, style = { "bold", "underline" } },
 		HopNextKey1 = { bg = cp.base, fg = cp.blue, style = "bold" },
-		HopNextKey2 = { bg = cp.base, fg = cp.teal, style = "bold,italic" },
+		HopNextKey2 = { bg = cp.base, fg = cp.teal, style = { "bold", "italic" } },
 		HopUnmatched = { bg = cp.base, fg = cp.overlay0 },
 	}
 end

--- a/lua/catppuccin/core/integrations/mini.lua
+++ b/lua/catppuccin/core/integrations/mini.lua
@@ -17,7 +17,7 @@ function M.get(cp)
 
 		MiniJump = { fg = cp.overlay2, bg = cp.pink },
 
-		MiniJump2dSpot = { bg = cp.base, fg = cp.peach, style = "bold,underline" },
+		MiniJump2dSpot = { bg = cp.base, fg = cp.peach, style = { "bold", "underline" } },
 
 		MiniStarterCurrent = {},
 		MiniStarterFooter = { fg = cp.yellow, style = "italic" },
@@ -42,10 +42,10 @@ function M.get(cp)
 
 		MiniSurround = { bg = cp.pink, fg = cp.surface1 },
 
-		MiniTablineCurrent = { fg = cp.text, bg = cp.base, style = "bold,italic" },
+		MiniTablineCurrent = { fg = cp.text, bg = cp.base, style = { "bold", "italic" } },
 		MiniTablineFill = { bg = bg_highlight },
 		MiniTablineHidden = { fg = cp.text, bg = inactive_bg },
-		MiniTablineModifiedCurrent = { fg = cp.base, bg = cp.text, style = "bold,italic" },
+		MiniTablineModifiedCurrent = { fg = cp.base, bg = cp.text, style = { "bold", "italic" } },
 		MiniTablineModifiedHidden = { fg = inactive_bg, bg = cp.text },
 		MiniTablineModifiedVisible = { fg = cp.surface1, bg = cp.subtext1 },
 		MiniTablineTabpagesection = { fg = cp.surface1, bg = cp.base },

--- a/lua/catppuccin/core/integrations/treesitter.lua
+++ b/lua/catppuccin/core/integrations/treesitter.lua
@@ -80,7 +80,7 @@ function M.get(cp)
 		-- TSURI               = { };    -- Any URI like a link or email.
 		--
 		-- Markdown tresitter parser support
-		TSURI = { fg = cp.rosewater, style = "italic,underline" }, -- urls, links and emails
+		TSURI = { fg = cp.rosewater, style = { "italic", "underline" } }, -- urls, links and emails
 		TSLiteral = { fg = cp.teal, style = "italic" }, -- used for inline code in markdown and for doc in python (""")
 		TSTextReference = { fg = cp.lavender, style = "bold" }, -- references
 		TSTitle = { fg = cp.blue, style = "bold" }, -- titles like: # Example

--- a/lua/catppuccin/core/mapper.lua
+++ b/lua/catppuccin/core/mapper.lua
@@ -34,7 +34,7 @@ local function get_base()
 		}, -- Screen-line at the cursor, when 'cursorline' is secp.  Low-priority if forecrust (ctermfg OR guifg) is not secp.
 		Directory = { fg = cp.blue }, -- directory names (and other special names in listings)
 		EndOfBuffer = { fg = cp.base }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
-		ErrorMsg = { fg = cp.red, style = "bold,italic" }, -- error messages on the command line
+		ErrorMsg = { fg = cp.red, style = { "bold", "italic" } }, -- error messages on the command line
 		VertSplit = { fg = cp.crust }, -- the column separating vertically split windows
 		Folded = { fg = cp.blue, bg = cp.surface1 }, -- line used for closed folds
 		FoldColumn = { bg = cp.base, fg = cp.overlay0 }, -- 'foldcolumn'

--- a/lua/catppuccin/utils/data.lua
+++ b/lua/catppuccin/utils/data.lua
@@ -8,13 +8,4 @@ function M.set_of(list)
     return set
 end
 
--- https://www.codegrepper.com/code-examples/lua/lua+split+string+on+comma
-function M.split(s, delimiter)
-    local result = {}
-    for match in (s..delimiter):gmatch("(.-)"..delimiter) do
-        table.insert(result, match)
-	end
-    return result
-end
-
 return M

--- a/lua/catppuccin/utils/util.lua
+++ b/lua/catppuccin/utils/util.lua
@@ -1,8 +1,5 @@
-local udata = require("catppuccin.utils.data")
-
 local g = vim.g
 local util = {}
-
 
 local has_nvim07 = vim.fn.has("nvim-0.7")
 
@@ -15,8 +12,12 @@ function util.highlight(group, color)
 		else
 			if color.style then
 				if color.style ~= "NONE" then
-					for _, style in pairs(udata.split(color.style, ",")) do
-						color[style] = true
+					if type(color.style) == "table" then
+						for _, style in ipairs(color.style) do
+							color[style] = true
+						end
+					else
+						color[color.style] = true
 					end
 				end
 			end
@@ -26,6 +27,9 @@ function util.highlight(group, color)
 		end
 	else
 		-- Doc: :h highlight-gui
+		if color.style and type(color.style) == "table" then
+			color.style = table.concat(color.style, ",")
+		end
 		local style = color.style and "gui=" .. color.style or "gui=NONE"
 		local fg = color.fg and "guifg=" .. color.fg or "guifg=NONE"
 		local bg = color.bg and "guibg=" .. color.bg or "guibg=NONE"


### PR DESCRIPTION
Related: https://github.com/catppuccin/nvim/issues/169

legacy `vim.cmd`
```
014.030  000.077  000.077: require('catppuccin')
014.077  000.045  000.045: require('catppuccin.config')
014.257  000.041  000.041: require('catppuccin.utils.util')
014.260  000.090  000.049: require('catppuccin.main')
014.448  000.050  000.050: require('catppuccin.utils.hsluv')
014.451  000.147  000.097: require('catppuccin.utils.colors')
014.547  000.027  000.027: require('catppuccin.utils.echo')
014.549  000.061  000.034: require('catppuccin.core.palettes.init')
014.615  000.063  000.063: require('catppuccin.core.palettes.mocha')
014.666  000.031  000.031: require('catppuccin.core.palettes.latte')
014.668  000.215  000.060: require('catppuccin.lib.ui')
014.669  000.407  000.045: require('catppuccin.core.mapper')
014.759  000.045  000.045: require('catppuccin.core.integrations.dashboard')
014.814  000.048  000.048: require('catppuccin.core.integrations.bufferline')
014.872  000.034  000.034: require('catppuccin.core.integrations.gitsigns')
014.915  000.036  000.036: require('catppuccin.core.integrations.telescope')
015.024  000.101  000.101: require('catppuccin.core.integrations.cmp')
015.122  000.064  000.064: require('catppuccin.core.integrations.treesitter')
015.228  000.074  000.074: require('catppuccin.core.integrations.native_lsp')
015.291  000.026  000.026: require('catppuccin.core.integrations.indent_blankline')
015.433  000.128  000.128: require('catppuccin.core.integrations.telekasten')
015.483  000.036  000.036: require('catppuccin.core.integrations.notify')
015.547  000.046  000.046: require('catppuccin.core.integrations.markdown')
015.587  000.023  000.023: require('catppuccin.core.integrations.symbols_outline')
016.157  000.005  000.005: require('vim.F')
017.477  001.331  001.326: sourcing /home/nullchilly/.local/share/nvim/site/pack/packer/start/theme/colors/catppuccin.vim
```

`nvim_set_hl`
```
013.244  000.053  000.053: require('catppuccin')
013.406  000.159  000.159: require('catppuccin.config')
013.593  000.060  000.060: require('catppuccin.utils.util')
013.596  000.103  000.044: require('catppuccin.main')
013.712  000.034  000.034: require('catppuccin.utils.hsluv')
013.716  000.064  000.030: require('catppuccin.utils.colors')
013.804  000.042  000.042: require('catppuccin.utils.echo')
013.806  000.068  000.026: require('catppuccin.core.palettes.init')
013.843  000.035  000.035: require('catppuccin.core.palettes.mocha')
013.872  000.025  000.025: require('catppuccin.core.palettes.latte')
013.873  000.156  000.029: require('catppuccin.lib.ui')
013.874  000.276  000.056: require('catppuccin.core.mapper')
013.976  000.061  000.061: require('catppuccin.core.integrations.telekasten')
014.014  000.031  000.031: require('catppuccin.core.integrations.symbols_outline')
014.045  000.026  000.026: require('catppuccin.core.integrations.bufferline')
014.105  000.030  000.030: require('catppuccin.core.integrations.native_lsp')
014.152  000.024  000.024: require('catppuccin.core.integrations.telescope')
014.196  000.024  000.024: require('catppuccin.core.integrations.indent_blankline')
014.261  000.028  000.028: require('catppuccin.core.integrations.cmp')
014.304  000.022  000.022: require('catppuccin.core.integrations.dashboard')
014.450  000.135  000.135: require('catppuccin.core.integrations.gitsigns')
014.499  000.037  000.037: require('catppuccin.core.integrations.markdown')
014.558  000.047  000.047: require('catppuccin.core.integrations.treesitter')
014.620  000.040  000.040: require('catppuccin.core.integrations.notify')
015.225  000.007  000.007: require('vim.F')
016.083  000.874  000.867: sourcing /home/nullchilly/.local/share/nvim/site/pack/packer/start/theme/colors/catppuccin.vim
```