### PR TITLE
Add Catppuccin Piccolo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.ptx
 *.cubin
 *.fatbin
+doc/tags

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ use { "catppuccin/nvim", as = "catppuccin" }
 For `lua`:
 
 ```lua
-vim.g.catppuccin_flavour = "macchiato" -- latte, frappe, macchiato, mocha
+vim.g.catppuccin_flavour = "macchiato" -- latte, frappe, macchiato, mocha, piccolo
 
 require("catppuccin").setup()
 
@@ -91,7 +91,7 @@ vim.cmd [[colorscheme catppuccin]]
 For `vimscript`:
 
 ```vim
-let g:catppuccin_flavour = "macchiato" " latte, frappe, macchiato, mocha
+let g:catppuccin_flavour = "macchiato" " latte, frappe, macchiato, mocha, piccolo
 
 lua << EOF
 require("catppuccin").setup()

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -129,7 +129,8 @@ the most popular ones:
 For `lua`:
 
 >
-    vim.g.catppuccin_flavour = "macchiato" -- latte, frappe, macchiato, mocha
+    vim.g.catppuccin_flavour = "macchiato" -- latte, frappe, macchiato, mocha,
+    piccolo
     
     require("catppuccin").setup()
     
@@ -140,7 +141,8 @@ For `lua`:
 For `vimscript`:
 
 >
-    let g:catppuccin_flavour = "macchiato" " latte, frappe, macchiato, mocha
+    let g:catppuccin_flavour = "macchiato" " latte, frappe, macchiato, mocha,
+    piccolo
     
     lua << EOF
     require("catppuccin").setup()
@@ -333,8 +335,8 @@ Here are the defaults
         mode_icon = ""
     },
     sett = {
-        text = ucolors.vary_color({ latte = latte.base }, clrs.surface0),
-        bkg = ucolors.vary_color({ latte = latte.crust }, clrs.surface0),
+        text = ucolors.vary_color({ latte = latte.base, piccolo = piccolo.base}, clrs.surface0),
+        bkg = ucolors.vary_color({ latte = latte.crust, piccolo = piccolo.crust }, clrs.surface0),
         diffs = clrs.mauve,
         extras = clrs.overlay1,
         curr_file = clrs.maroon,

--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -13,7 +13,7 @@ function M.get()
 		CursorColumn = { bg = cp.mantle }, -- Screen-column at the cursor, when 'cursorcolumn' is secp.
 		CursorLine = {
 			bg = ucolors.vary_color(
-				{ latte = ucolors.lighten(cp.mantle, 0.70, cp.base) },
+				{ latte = ucolors.lighten(cp.mantle, 0.70, cp.base), piccolo = ucolors.lighten(cp.mantle, 0.70, cp.base) },
 				ucolors.darken(cp.surface0, 0.64, cp.base)
 			),
 		}, -- Screen-line at the cursor, when 'cursorline' is secp.  Low-priority if forecrust (ctermfg OR guifg) is not secp.
@@ -26,7 +26,7 @@ function M.get()
 		SignColumn = { bg = cnf.transparent_background and cp.none or cp.base, fg = cp.surface1 }, -- column where |signs| are displayed
 		SignColumnSB = { bg = cp.crust, fg = cp.surface1 }, -- column where |signs| are displayed
 		Substitute = { bg = cp.surface1, fg = cp.pink }, -- |:substitute| replacement text highlighting
-		LineNr = { fg = ucolors.vary_color({ latte = cp.base0 }, cp.surface1) }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is secp.
+		LineNr = { fg = ucolors.vary_color({ latte = cp.base0, piccolo = cp.base0 }, cp.surface1) }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is secp.
 		CursorLineNr = { fg = cp.lavender }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line. highlights the number in numberline.
 		MatchParen = { fg = cp.peach, style = { "bold" } }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
 		ModeMsg = { fg = cp.text, style = { "bold" } }, -- 'showmode' message (e.g., "-- INSERT -- ")

--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -7,6 +7,7 @@ local b = vim.b
 local clrs = require("catppuccin.palettes.init").get_palette()
 local ucolors = require("catppuccin.utils.colors")
 local latte = require("catppuccin.palettes.latte")
+local piccolo = require("catppuccin.palettes.piccolo")
 
 local assets = {
 	left_separator = "",
@@ -16,8 +17,8 @@ local assets = {
 }
 
 local sett = {
-	text = ucolors.vary_color({ latte = latte.base }, clrs.surface0),
-	bkg = ucolors.vary_color({ latte = latte.crust }, clrs.surface0),
+	text = ucolors.vary_color({ latte = latte.base, piccolo = piccolo.base }, clrs.surface0),
+	bkg = ucolors.vary_color({ latte = latte.crust, piccolo = piccolo.crust }, clrs.surface0),
 	diffs = clrs.mauve,
 	extras = clrs.overlay1,
 	curr_file = clrs.maroon,

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local flavours = { "latte", "frappe", "macchiato", "mocha" }
+local flavours = { "latte", "frappe", "macchiato", "mocha", "piccolo" }
 
 function M.load()
 	local compiled = nil

--- a/lua/catppuccin/lib/ui.lua
+++ b/lua/catppuccin/lib/ui.lua
@@ -7,15 +7,15 @@ local ucolors = require("catppuccin.utils.colors")
 function M.dim()
 	local cp = require("catppuccin.palettes.init").get_palette()
 	if cnf.dim_inactive.shade == "dark" then
-		return ucolors.vary_color(
-			{ latte = ucolors.darken(cp.base, dim_percentage, cp.mantle) },
-			ucolors.darken(cp.base, dim_percentage, cp.mantle)
-		)
+		return ucolors.vary_color({
+			latte = ucolors.darken(cp.base, dim_percentage, cp.mantle),
+			piccolo = ucolors.darken(cp.base, dim_percentage, cp.mantle),
+		}, ucolors.darken(cp.base, dim_percentage, cp.mantle))
 	end
-	return ucolors.vary_color(
-		{ latte = ucolors.lighten("#FBFCFD", dim_percentage, cp.base) },
-		ucolors.lighten(cp.surface0, dim_percentage, cp.base)
-	)
+	return ucolors.vary_color({
+		latte = ucolors.lighten("#FBFCFD", dim_percentage, cp.base),
+		piccolo = ucolors.lighten("#FFFDF7", dim_percentage, cp.base),
+	}, ucolors.lighten(cp.surface0, dim_percentage, cp.base))
 end
 
 return M

--- a/lua/catppuccin/palettes/init.lua
+++ b/lua/catppuccin/palettes/init.lua
@@ -7,7 +7,7 @@ function M.get_palette()
 	local flvr = vim.g.catppuccin_flavour
 
 	local palette = require("catppuccin.palettes.mocha")
-	if flvr == "mocha" or flvr == "latte" or flvr == "macchiato" or flvr == "frappe" then
+	if flvr == "mocha" or flvr == "latte" or flvr == "macchiato" or flvr == "frappe" or flvr == "piccolo" then
 		palette = require("catppuccin.palettes." .. flvr)
 	end
 

--- a/lua/catppuccin/palettes/piccolo.lua
+++ b/lua/catppuccin/palettes/piccolo.lua
@@ -1,0 +1,37 @@
+-- NOTE: references for Catppuccin Latte
+-- monochromatic: https://coolors.co/fbf8f4-e9e6e6-d7d3d9-c4c1cb-b2aebd-a09cb0-8e89a2-7b7794-696487-575279
+-- analogous 1: https://coolors.co/de9584-dd7878-ec83d0-822fee-e64553-bb0d33-fe640b
+-- analogous 2: https://coolors.co/7287fd-2a6ef5-04a5e5-e49320-209fb5-40a02b-179299
+
+local color_palette = {
+	rosewater = "#dc8a78",
+	flamingo = "#DD7878",
+	pink = "#d26ab6",
+	mauve = "#8839EF",
+	red = "#D20F39",
+	maroon = "#E64553",
+	peach = "#FE640B",
+	yellow = "#df8e1d",
+	green = "#40A02B",
+	teal = "#179299",
+	sky = "#04A5E5",
+	sapphire = "#209FB5",
+	blue = "#1e66f5",
+	lavender = "#7287FD",
+
+	text = "#4C4F69",
+	subtext1 = "#5C5F77",
+	subtext0 = "#6C6F85",
+	overlay2 = "#7C7F93",
+	overlay1 = "#8C8FA1",
+	overlay0 = "#9CA0B0",
+	surface2 = "#ACB0BE",
+	surface1 = "#BCC0CC",
+	surface0 = "#CCD0DA",
+
+	base = "#FDF7DF",
+	mantle = "#FBF1C7",
+	crust = "#F9EBAF",
+}
+
+return color_palette


### PR DESCRIPTION
Summary
---- 
This PR adds another light variant theme with a soft yellow background, similar to Gruvbox Light.

Gif
----
![catppuccin-piccolo](https://user-images.githubusercontent.com/3199183/180118000-fd1d33a6-4dfa-4997-9a44-95f0eae89711.gif)


Caveats
----
I'm perfectly fine if this PR is closed, since the changes here are very minimal (only base, mantle, crust and pink) and can potentially be achieved locally by overriding the colors. I just thought it would be nice to have another light variant for Catppuccin :slightly_smiling_face: 