### PR TITLE
fix(feline): fix spacing between components, add label for Lsp indicator

### DIFF
--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -210,7 +210,7 @@ function M.get()
 	}
 
 	components.active[1][9] = {
-		provider = assets.right_separator,
+		provider = "█" .. assets.right_separator,
 		hl = {
 			fg = sett.diffs,
 			bg = sett.bkg,
@@ -366,7 +366,7 @@ function M.get()
 			fg = sett.extras,
 			bg = sett.bkg,
 		},
-		icon = "   ",
+		icon = "  ",
 		left_sep = invi_sep,
 		right_sep = invi_sep,
 	}
@@ -374,7 +374,7 @@ function M.get()
 	components.active[3][2] = {
 		provider = function()
 			if next(vim.lsp.buf_get_clients()) ~= nil then
-				return " "
+				return "  Lsp "
 			else
 				return ""
 			end


### PR DESCRIPTION
This PR contains the following proposal:
- add a bar character to the end of the git component in order to have consistent spacing
- add a label to the Lsp server icon in order to have an indication of what the icon represents
- change the spaces in the git icon in order to have consistent spacing

With no separator:
fix: ![fix_feline_no_separator](https://user-images.githubusercontent.com/3298487/182427869-239cb6b6-492c-4773-b5ca-d71aad76ab4a.png)
no_fix: ![nofix_feline_no_separator](https://user-images.githubusercontent.com/3298487/182427904-c8997607-4a0f-43a0-82bb-b2848c9d08dd.png)

With separator:
fix: ![fix_feline_with_separator](https://user-images.githubusercontent.com/3298487/182428009-6004df2b-4e45-4426-b4e2-9ae5c4b24321.png)
no_fix: ![nofix_feline_with_separator](https://user-images.githubusercontent.com/3298487/182428050-907fd75d-247b-40b2-a669-605f6c33bb62.png)

