### PR TITLE
Adding support to nvim-navic

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This port of Catppuccin is special because it was the first one and the one that
     -   [VimWiki](https://github.com/vimwiki/vimwiki)
     -   [Leap.nvim](https://github.com/ggandor/leap.nvim)
     -   [Nvim-navic](https://github.com/SmiteshP/nvim-navic)
-    -   [vim-clap](https://github.com/liuchengxu/vim-clap)
+    -   [Vim-clap](https://github.com/liuchengxu/vim-clap)
 
 # Installation
 
@@ -375,6 +375,21 @@ local sign = vim.fn.sign_define
 sign("DapBreakpoint", { text = "●", texthl = "DapBreakpoint", linehl = "", numhl = ""})
 sign("DapBreakpointCondition", { text = "●", texthl = "DapBreakpointCondition", linehl = "", numhl = ""})
 sign("DapLogPoint", { text = "◆", texthl = "DapLogPoint", linehl = "", numhl = ""})
+```
+
+-   **Nvim-navic:** setting `enabled` to `true`:
+
+```lua
+integration = {
+	navic = true
+}
+```
+
+```lua
+-- You need to enable highlight in nvim-navic setting or it won't work
+require("nvim-navic").setup {
+	highlight = true
+}
 ```
 
 # Customize highlights

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This port of Catppuccin is special because it was the first one and the one that
     -   [Beacon.nvim](https://github.com/DanilaMihailov/beacon.nvim)
     -   [VimWiki](https://github.com/vimwiki/vimwiki)
     -   [Leap.nvim](https://github.com/ggandor/leap.nvim)
+    -   [Nvim-navic](https://github.com/SmiteshP/nvim-navic)
 
 # Installation
 
@@ -200,6 +201,7 @@ require("catppuccin").setup({
 		aerial = false,
 		vimwiki = true,
 		beacon = true,
+        navic = false,
 	},
 	color_overrides = {},
 	highlight_overrides = {},

--- a/lua/catppuccin/config.lua
+++ b/lua/catppuccin/config.lua
@@ -85,6 +85,7 @@ local default_config = {
 		aerial = false,
 		vimwiki = true,
 		beacon = true,
+		navic = false,
 	},
 	color_overrides = {},
 	highlight_overrides = {},

--- a/lua/catppuccin/groups/integrations/navic.lua
+++ b/lua/catppuccin/groups/integrations/navic.lua
@@ -1,0 +1,36 @@
+local M = {}
+
+function M.get()
+	return {
+		NavicIconsFile = { fg = cp.blue, bg = "NONE" },
+		NavicIconsModule = { fg = cp.blue, bg = "NONE" },
+		NavicIconsNamespace = { fg = cp.blue, bg = "NONE" },
+		NavicIconsPackage = { fg = cp.blue, bg = "NONE" },
+		NavicIconsClass = { fg = cp.yellow, bg = "NONE" },
+		NavicIconsMethod = { fg = cp.blue, bg = "NONE" },
+		NavicIconsProperty = { fg = cp.green, bg = "NONE" },
+		NavicIconsField = { fg = cp.green, bg = "NONE" },
+		NavicIconsConstructor = { fg = cp.blue, bg = "NONE" },
+		NavicIconsEnum = { fg = cp.green, bg = "NONE" },
+		NavicIconsInterface = { fg = cp.yellow, bg = "NONE" },
+		NavicIconsFunction = { fg = cp.blue, bg = "NONE" },
+		NavicIconsVariable = { fg = cp.flamingo, bg = "NONE" },
+		NavicIconsConstant = { fg = cp.peach, bg = "NONE" },
+		NavicIconsString = { fg = cp.green, style = cnf.styles.strings, bg = "NONE" },
+		NavicIconsNumber = { fg = cp.peach, bg = "NONE" },
+		NavicIconsBoolean = { fg = cp.peach, bg = "NONE" },
+		NavicIconsArray = { fg = cp.peach, bg = "NONE" },
+		NavicIconsObject = { fg = cp.peach, bg = "NONE" },
+		NavicIconsKey = { fg = cp.pink, style = cnf.styles.keywords, bg = "NONE" },
+		NavicIconsNull = { fg = cp.peach, bg = "NONE" },
+		NavicIconsEnumMember = { fg = cp.red, bg = "NONE" },
+		NavicIconsStruct = { fg = cp.blue, bg = "NONE" },
+		NavicIconsEvent = { fg = cp.blue, bg = "NONE" },
+		NavicIconsOperator = { fg = cp.sky, bg = "NONE" },
+		NavicIconsTypeParameter = { fg = cp.blue, bg = "NONE" },
+		NavicText = { fg = cp.teal, bg = "NONE" },
+		NavicSeparator = { fg = cp.text, bg = "NONE" },
+	}
+end
+
+return M


### PR DESCRIPTION
I added support to nvim-navic... I've tried to base the colors on the cmp and on treesitter. 

One issue that I'm not sure how to solve is the background. I thought putting `NONE` on all of them would make it transparent, but it is not happening, when I set it in lualine for example I'm getting the `base` background instead. Perhaps you could point me to how to solve this :)