### PR TITLE
Adding inactive component to feline

### DIFF
--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -96,6 +96,7 @@ function M.get()
 	table.insert(components.active, {}) -- (1) left
 	table.insert(components.active, {}) -- (2) center
 	table.insert(components.active, {}) -- (3) right
+	table.insert(components.inactive, {})
 
 	-- global components
 	local invi_sep = {
@@ -444,6 +445,17 @@ function M.get()
 		},
 	}
 	-- ######## Right
+
+	-- Inanctive components
+	components.inactive[1][1] = {
+		provider = function()
+			return " " .. string.upper(vim.bo.ft) .. " "
+		end,
+		hl = {
+			fg = clrs.overlay2,
+			bg = clrs.mantle,
+		},
+	}
 
 	return components
 end


### PR DESCRIPTION
In feline integration is not set an option for inactive components.
The problem is, that you don't know what other split-windows are. To explain it better see the following screenshot.

This shows the DAP-UI. Here is set `laststatus = 3` 
<img width="1912" alt="dapui-lastst=3" src="https://user-images.githubusercontent.com/39212564/186997251-c79a9a84-ac0b-4d01-bf03-05138b2f4b58.png">
You don't know where the *scopes*, the *breakpoint*, the *wathes* and so on they are.

By switching the split-windows you see only a black bar on the bottom.

https://user-images.githubusercontent.com/39212564/186997584-e3431164-968e-4712-a49c-80caf92aa831.mov

With `laststatus = 2` you have in every split-window a black bar at the bottom.
<img width="1912" alt="dapui-lastst=2" src="https://user-images.githubusercontent.com/39212564/186997801-64e7bfc3-f7e6-4203-92d8-57462ff33c66.png">

With the inactive component in feline, it looks like this...
Here is set `laststatus = 2`...
<img width="1912" alt="dapui-lastst=2" src="https://user-images.githubusercontent.com/39212564/186998020-3be79988-ab4d-481c-a1a5-0bdff8729ae8.png">
You see exactly where what is
With `laststatus = 3` you see what split-window is in the bottom, by switching the pane...

https://user-images.githubusercontent.com/39212564/186998310-db65060b-d54e-4b6b-84df-299aef2e9dcd.mov

Further examples... 
*Symbols-Outline*:
**Without** inactive component:
<img width="1912" alt="symbols_outlne-lastst=3" src="https://user-images.githubusercontent.com/39212564/186998479-7d829c28-892f-40dc-92dc-18f50376daa6.png">

**With** inactive component:
<img width="1912" alt="symbols_outline-lastst=3" src="https://user-images.githubusercontent.com/39212564/186998523-6731618a-e879-4e3d-bbe6-ef09f9a5dc24.png">

*Trouble*:
**Without** inactive component:
<img width="1912" alt="trouble-lastst=2" src="https://user-images.githubusercontent.com/39212564/186998692-d55abf2f-3f2d-42f2-8983-7b0780e0e83e.png">

**With** inactive component:
<img width="1912" alt="trouble-lastst=2" src="https://user-images.githubusercontent.com/39212564/186998718-a5c8cb1c-a37a-4d40-9429-e7920db1365b.png">

And the list go on, like with Nvim-Tree, or Split-Windows, or QuickFixList etc.

The only think to add, is in the feline setup, to force inactive these windows:

```lua
require('feline').setup({
    components = ctp_feline.get(),
    force_inactive = {
        filetypes = {
            'packer',
            'NvimTree',
            'Trouble',
            'Outline',
            'qf',
            'help',
            'dapui_scopes',
            'dapui_breakpoints',
            'dapui_stacks',
            'dapui_watches',
            'dapui_repl',
            'dap-repl',
            'dapui_console',
            'lspinfo',
        },
        buftypes = { 'terminal' },
        bufnames = {},
    },
})
```
If you want to add something else, which is not in the force_inactive table above, you can find the window name by typing in the command line `:lua print(vim.bo.ft)` and then adding the window name in the table.