### PR TITLE
Fix: editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ root = true
 end_of_line = lf
 charset = utf-8
 insert_final_newline = true
-indent_style = tabs
+indent_style = tab
 indent_size = 4
 
 [*.txt]


### PR DESCRIPTION
Changes `indent_style = tabs` -> `indent_style = tab` since "tabs" isn't possible value for indent_style as stated here: https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#indent_style.