### PR TITLE
chore(readme): Sort integrations in case-insensitive alphabetical order.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,38 +142,40 @@ Handles the style of general hi groups (see `:h highlight-args`):
 
 ## Integrations
 
-List of supported plugins and their modules (See [Special integrations](https://github.com/catppuccin/nvim#special-integrations) for more)
+catppuccin-nvim provides theme support for other plugins in the Neovim ecosystem and extended Neovim functionality through _integrations_.
 
-| Plugin | Module |
-| ------ | ------ |
-| [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) | treesitter |
-| [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) | telescope |
-| [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) | cmp |
-| [lspsaga.nvim](https://github.com/glepnir/lspsaga.nvim/) | lsp_saga |
-| [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim) | gitsigns |
-| [trouble.nvim](https://github.com/folke/trouble.nvim) | lsp_trouble |
-| [which-key.nvim](https://github.com/folke/which-key.nvim) | which_key |
-| [barbar.nvim](https://github.com/romgrk/barbar.nvim) | barbar |
-| [nvim-tree.lua](https://github.com/kyazdani42/nvim-tree.lua) | nvimtree |
-| [vim-gitgutter](https://github.com/airblade/vim-gitgutter) | gitgutter |
-| [fern.vim](https://github.com/lambdalisue/fern.vim) | fern |
-| [dashboard-nvim](https://github.com/glepnir/dashboard-nvim) | dashboard |
-| [Markdown](https://www.markdownguide.org/) | markdown |
-| [lightspeed.nvim](https://github.com/ggandor/lightspeed.nvim) | lightspeed |
-| [leap.nvim](https://github.com/ggandor/leap.nvim) | leap |
-| [hop.nvim](https://github.com/phaazon/hop.nvim) | hop |
-| [vim-sneak](https://github.com/justinmk/vim-sneak) | vim_sneak |
-| [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow) | ts_rainbow |
-| [neogit](https://github.com/TimUntersberger/neogit) | neogit |
-| [telekasten.nvim](https://github.com/renerocksai/telekasten.nvim) | telekasten |
-| [nvim-notify](https://github.com/rcarriga/nvim-notify) | notify |
-| [symbols-outline.nvim](https://github.com/simrat39/symbols-outline.nvim) | symbols_outline |
-| [mini.nvim](https://github.com/echasnovski/mini.nvim) | mini |
-| [aerial.nvim](https://github.com/stevearc/aerial.nvim) | aerial |
-| [beacon.nvim](https://github.com/DanilaMihailov/beacon.nvim) | beacon |
-| [vimwiki](https://github.com/vimwiki/vimwiki) | vimwiki |
-| [overseer.nvim](https://github.com/stevearc/overseer.nvim) | overseer |
+Below is a list of supported plugins and their corresponding integration module. (See [Special integrations](https://github.com/catppuccin/nvim#special-integrations) for more.)
+
+| Plugin                                                                                | Module             |
+| ------------------------------------------------------------------------------------- | ------------------ |
+| [aerial.nvim](https://github.com/stevearc/aerial.nvim)                                | aerial             |
+| [barbar.nvim](https://github.com/romgrk/barbar.nvim)                                  | barbar             |
+| [beacon.nvim](https://github.com/DanilaMihailov/beacon.nvim)                          | beacon             |
+| [dashboard-nvim](https://github.com/glepnir/dashboard-nvim)                           | dashboard          |
+| [fern.vim](https://github.com/lambdalisue/fern.vim)                                   | fern               |
+| [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim)                           | gitsigns           |
+| [hop.nvim](https://github.com/phaazon/hop.nvim)                                       | hop                |
+| [leap.nvim](https://github.com/ggandor/leap.nvim)                                     | leap               |
+| [lightspeed.nvim](https://github.com/ggandor/lightspeed.nvim)                         | lightspeed         |
+| [lspsaga.nvim](https://github.com/glepnir/lspsaga.nvim/)                              | lsp_saga           |
+| [Markdown](https://www.markdownguide.org/)                                            | markdown           |
+| [mini.nvim](https://github.com/echasnovski/mini.nvim)                                 | mini               |
+| [neogit](https://github.com/TimUntersberger/neogit)                                   | neogit             |
+| [nvim-cmp](https://github.com/hrsh7th/nvim-cmp)                                       | cmp                |
+| [nvim-notify](https://github.com/rcarriga/nvim-notify)                                | notify             |
+| [nvim-tree.lua](https://github.com/kyazdani42/nvim-tree.lua)                          | nvimtree           |
 | [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) | treesitter_context |
+| [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)                 | treesitter         |
+| [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)                            | ts_rainbow         |
+| [overseer.nvim](https://github.com/stevearc/overseer.nvim)                            | overseer           |
+| [symbols-outline.nvim](https://github.com/simrat39/symbols-outline.nvim)              | symbols_outline    |
+| [telekasten.nvim](https://github.com/renerocksai/telekasten.nvim)                     | telekasten         |
+| [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)                    | telescope          |
+| [trouble.nvim](https://github.com/folke/trouble.nvim)                                 | lsp_trouble        |
+| [vim-gitgutter](https://github.com/airblade/vim-gitgutter)                            | gitgutter          |
+| [vim-sneak](https://github.com/justinmk/vim-sneak)                                    | vim_sneak          |
+| [vimwiki](https://github.com/vimwiki/vimwiki)                                         | vimwiki            |
+| [which-key.nvim](https://github.com/folke/which-key.nvim)                             | which_key          |
 
 These integrations allow catppuccin to set the theme of various plugins. To enable an integration you just need to set it to `true`, for example:
 
@@ -255,31 +257,10 @@ require("catppuccin").setup({
 	},
 })
 ```
+
 </details>
 
 ### Special integrations
-<details> <summary>nvim-lspconfig</summary>
-
-Setting `enabled` to `true` enables this integration. In the inners tables you can set the style for the diagnostics, both `virtual_text` (what you see on the side) and `underlines` (what points directly at the thing (e.g. an error)).
-
-```lua
-native_lsp = {
-	enabled = true,
-	virtual_text = {
-		errors = { "italic" },
-		hints = { "italic" },
-		warnings = { "italic" },
-		information = { "italic" },
-	},
-	underlines = {
-		errors = { "underline" },
-		hints = { "underline" },
-		warnings = { "underline" },
-		information = { "underline" },
-	},
-},
-```
-</details>
 
 <details> <summary>bufferline.nvim</summary>
 
@@ -310,6 +291,7 @@ bufferline.setup {
 	},
 }
 ```
+
 </details>
 
 <details> <summary>feline.nvim</summary>
@@ -388,8 +370,52 @@ mode_colors = {
 }
 ```
 
-<br />
+</p>
 </details>
+</details>
+
+<details> <summary>fidget.nvim</summary>
+
+Set fidget module to `true`
+
+```lua
+fidget = true
+```
+
+Then set `window.blend` to `0`:
+
+```lua
+require("fidget").setup {
+    window = {
+        blend = 0,
+    },
+	-- ... the rest of your fidget config
+}
+```
+
+</details>
+
+<details> <summary>indent-blankline.nvim</summary>
+
+Setting `enabled` to `true` enables this integration. `colored_indent_levels` enables char highlights per indent level. Follow the instructions [here](https://github.com/lukas-reineke/indent-blankline.nvim#with-custom-gindent_blankline_char_highlight_list) to set the latter up.
+
+```lua
+indent_blankline = {
+	enabled = true,
+	colored_indent_levels = false,
+},
+```
+
+</details>
+
+<details> <summary>lightline.vim</summary>
+
+Use this to set it up (Note: `catppuccin` is the only valid colorscheme name. It will pick the one set in your config):
+
+```vim
+let g:lightline = {'colorscheme': 'catppuccin'}
+```
+
 </details>
 
 <details> <summary>lualine.nvim</summary>
@@ -404,18 +430,7 @@ require('lualine').setup {
 	}
 }
 ```
-</details>
 
-<details> <summary>indent-blankline.nvim</summary>
-
-Setting `enabled` to `true` enables this integration. `colored_indent_levels` enables char highlights per indent level. Follow the instructions [here](https://github.com/lukas-reineke/indent-blankline.nvim#with-custom-gindent_blankline_char_highlight_list) to set the latter up.
-
-```lua
-indent_blankline = {
-	enabled = true,
-	colored_indent_levels = false,
-},
-```
 </details>
 
 <details> <summary>neo-tree.nvim</summary>
@@ -431,6 +446,7 @@ integration = {
 	}
 }
 ```
+
 </details>
 
 <details> <summary>nvim-dap</a> & nvim-dap-ui</a> </summary>
@@ -456,24 +472,31 @@ sign("DapBreakpoint", { text = "●", texthl = "DapBreakpoint", linehl = "", num
 sign("DapBreakpointCondition", { text = "●", texthl = "DapBreakpointCondition", linehl = "", numhl = ""})
 sign("DapLogPoint", { text = "◆", texthl = "DapLogPoint", linehl = "", numhl = ""})
 ```
+
 </details>
 
-<details> <summary>lightline.vim</summary>
+<details> <summary>nvim-lspconfig</summary>
 
-Use this to set it up (Note: `catppuccin` is the only valid colorscheme name. It will pick the one set in your config):
+Setting `enabled` to `true` enables this integration. In the inners tables you can set the style for the diagnostics, both `virtual_text` (what you see on the side) and `underlines` (what points directly at the thing (e.g. an error)).
 
-```vim
-let g:lightline = {'colorscheme': 'catppuccin'}
+```lua
+native_lsp = {
+	enabled = true,
+	virtual_text = {
+		errors = { "italic" },
+		hints = { "italic" },
+		warnings = { "italic" },
+		information = { "italic" },
+	},
+	underlines = {
+		errors = { "underline" },
+		hints = { "underline" },
+		warnings = { "underline" },
+		information = { "underline" },
+	},
+},
 ```
-</details>
 
-<details> <summary>vim-clap</summary>
-
-Use this to set it up:
-
-```vim
-let g:clap_theme = 'catppuccin'
-```
 </details>
 
 <details> <summary>nvim-navic</summary>
@@ -493,29 +516,20 @@ require("nvim-navic").setup {
 	highlight = true
 }
 ```
+
 </details>
 
-<details> <summary>fidget.nvim</summary>
+<details> <summary>vim-clap</summary>
 
-Set fidget module to `true`
+Use this to set it up:
 
-```lua
-fidget = true
+```vim
+let g:clap_theme = 'catppuccin'
 ```
 
-Then set `window.blend` to `0`:
-
-```lua
-require("fidget").setup {
-    window = {
-        blend = 0,
-    },
-	-- ... the rest of your fidget config
-}
-```
 </details>
 
-If you'd like to know which highlight groups are being affected by catppuccin, checkout this directory: [`lua/catppuccin/groups/integrations/`](https://github.com/catppuccin/nvim/tree/main/lua/catppuccin/groups/integrations).
+If you'd like to know which highlight groups are being affected by catppuccin, check out this directory: [`lua/catppuccin/groups/integrations/`](https://github.com/catppuccin/nvim/tree/main/lua/catppuccin/groups/integrations).
 
 # Customize highlights
 
@@ -525,358 +539,5 @@ If you'd like to know which highlight groups are being affected by catppuccin, c
 local latte = require("catppuccin.palettes").get_palette "latte"
 local frappe = require("catppuccin.palettes").get_palette "frappe"
 local macchiato = require("catppuccin.palettes").get_palette "macchiato"
-local mocha = require("catppuccin.palettes").get_palette "mocha"
-
-vim.g.catppuccin_flavour = "macchiato" -- Has to be set in order for empty argument to work
-local colors = require("catppuccin.palettes").get_palette() -- g:catppuccin_flavour's palette
+local
 ```
-
-Will returns a table where the key is the name of the color and the value is its hex value.
-
-## Overwriting highlight groups
-
-Global highlight groups can be overwritten in the setting like so:
-
-```lua
-custom_highlights = {
-	<hi_group> = { <fields> }
-}
-```
-
-Here is an example:
-
-```lua
-vim.g.catppuccin_flavour = "macchiato"
-local colors = require("catppuccin.palettes").get_palette() -- fetch colors from g:catppuccin_flavour palette
-require("catppuccin").setup {
-	custom_highlights = {
-		Comment = { fg = colors.flamingo },
-		TSConstBuiltin = { fg = colors.peach, style = {} },
-		TSConstant = { fg = colors.sky },
-		TSComment = { fg = colors.surface2, style = { "italic" } }
-	}
-}
-```
-
-Per flavour highlight groups can be overwritten in the setting like so:
-
-```lua
-highlight_overrides = {
-	all = { -- Will be replaced with custom_highlights if it exists
-		<hi_group> = { <fields> }
-	}, -- Same for each flavour
-	latte = {},
-	frappe = {},
-	macchiato = {},
-	mocha = {},
-}
-```
-
-Here is an example:
-
-```lua
-local ucolors = require "catppuccin.utils.colors"
-local latte = require("catppuccin.palettes").get_palette "latte"
-local frappe = require("catppuccin.palettes").get_palette "frappe"
-local macchiato = require("catppuccin.palettes").get_palette "macchiato"
-local mocha = require("catppuccin.palettes").get_palette "mocha"
-
-vim.g.catppuccin_flavour = "macchiato"
-local colors = require("catppuccin.palettes").get_palette() -- return vim.g.catppuccin_flavour palette
-
-require("catppuccin").setup {
-	highlight_overrides = {
-		all = {
-			CmpBorder = { fg = "#3e4145" },
-		},
-		latte = {
-			Normal = { fg = ucolors.darken(latte.base, 0.7, latte.mantle) },
-		},
-		frappe = {
-			TSConstBuiltin = { fg = frappe.peach, style = {} },
-			TSConstant = { fg = frappe.sky },
-			TSComment = { fg = frappe.surface2, style = { "italic" } },
-		},
-		macchiato = {
-			LineNr = { fg = macchiato.overlay1 }
-		},
-		mocha = {
-			Comment = { fg = mocha.flamingo },
-		},
-	},
-}
-```
-
-Aditionally, if you want to load other custom highlights later, you may use this function:
-
-```lua
-require("catppuccin.lib.highlighter").syntax()
-```
-
-For example:
-
-```lua
-local colors = require("catppuccin.palettes").get_palette() -- fetch colors from palette
-require("catppuccin.lib.highlighter").syntax({
-	Comment = { fg = colors.surface0 }
-})
-```
-
-> Note: custom highlights loaded using the `require("catppuccin.lib.highlighter").syntax()` function won't be pre-compiled. See [compile](https://github.com/catppuccin/nvim/tree/main#compile).
-
-## Overwriting colors
-
-Colors can be overwritten using `color_overrides` in the setting, like so:
-
-```lua
-require("catppuccin").setup {
-	color_overrides = {
-		all = {
-			text = "#ffffff",
-		},
-		latte = {
-			base = "#ff0000",
-			mantle = "#242424",
-			crust = "#474747",
-		},
-		frappe = {},
-		macchiato = {},
-		mocha = {},
-	}
-}
-```
-
-# Compile
-
-Catppuccin is a highly customizable and configurable colorscheme. This does however come at the cost of complexity and execution time.
-
-Catppuccin can pre compute the results of your configuration and store the results in a compiled lua file. We use these precached values to set it's highlights.
-
-## Enable
-
-Setting `enabled` to `true` enables this feature:
-
-```lua
-compile = {
-	enabled = true,
-	path = vim.fn.stdpath "cache" .. "/catppuccin"
-}
-```
-
-By default catppuccin writes the compiled results into the system's cache directory.
-Note: On windows we replace `/` with `\` by default
-
-## Compile commands
-
-```vim
-:CatppuccinCompile " Create/update the compile file
-:CatppuccinClean " Delete compiled file
-:CatppuccinStatus " Compile status
-```
-
-NOTE: You have to reload setup function in order for compile to register new config. Please refer to [auto compile](https://github.com/catppuccin/nvim#auto-compile)
-
-Catppuccin also provides these functions to work with the catppuccin compiler.
-
-```lua
-local catppuccin = require('catppuccin')
-
--- Create/update the compile files
-catppuccin.compile()
-
--- Delete compiled files
-catppuccin.clean()
-
--- Show compile status
-catppuccin.status()
-```
-
-## Post-install/update hooks
-
-Packer.nvim
-
-```lua
--- It's recommended to add `:CatppuccinCompile` to post-install/update hooks
-use {
-	"catppuccin/nvim",
-	as = "catppuccin",
-	run = ":CatppuccinCompile"
-}
-```
-
-Vim-plug
-
-```lua
--- It's recommended to add `:CatppuccinCompile` to post-update hooks
-Plug 'catppuccin/nvim', {'as': 'catppuccin', 'do': 'CatppuccinCompile'}
-```
-
-## Auto compile
-
-Packer.nvim
-
-```lua
--- If you want catppuccin setup function to actually reload without restarting nvim
-require("packer").init {
-	auto_reload_compiled = true
-}
-```
-
-```lua
--- Create an autocmd User PackerCompileDone to update it every time packer is compiled
-vim.api.nvim_create_autocmd("User", {
-	pattern = "PackerCompileDone",
-	callback = function()
-		vim.cmd "CatppuccinCompile"
-		vim.defer_fn(function()
-			vim.cmd "colorscheme catppuccin"
-		end, 0) -- Defered for live reloading
-	end
-})
-```
-
-```lua
--- PackerCompile on save if your config file is in plugins.lua or catppuccin.lua
--- DO NOT put the autocmd inside the plugin specification file or you will get 2 ^ x files open after x saves
-vim.api.nvim_create_autocmd("BufWritePost", {
-	pattern = { "plugins.lua", "catppuccin.lua" },
-	callback = function()
-		vim.cmd "PackerCompile"
-	end
-})
-```
-
-Vim-plug
-
-```vim
-" Auto reload on save if catppuccin config is written inside init.vim
-autocmd BufWritePost init.vim :source init.vim | CatppuccinCompile
-```
-
-## Acknowledge
-
-[nightfox.nvim#compile](https://github.com/EdenEast/nightfox.nvim#compile)
-
-## Hooks
-
-Use them to execute code at certain events. These are the ones available:
-
-| Autocmd          | Description                  |
-| ---------------- | ---------------------------- |
-| `ColorSchemePre` | Before loading a colorscheme |
-| `ColorScheme`    | After loading a colorscheme  |
-
-They can be used like so:
-
-```lua
-vim.api.nvim_create_autocmd("ColorSchemePre", {
-	pattern = "*",
-	callback = function()
-		print "I ran before loading Catppuccin!"
-	end
-})
-
-vim.api.nvim_create_autocmd("ColorScheme", {
-	pattern = "*",
-	callback = function()
-		local colors = require("catppuccin.palettes").get_palette()
-		-- do something with colors
-	end
-})
-```
-
-# FAQ
-
-## Transparent background tweak
-
-Add this to `custom_highlights` settings
-
-```lua
-local colors = require("catppuccin.palettes").get_palette()
-colors.none = "NONE"
-require("catppuccin").setup {
-	custom_highlights = {
-		Comment = { fg = colors.overlay1 },
-		LineNr = { fg = colors.overlay1 },
-		CursorLine = { bg = colors.none },
-		CursorLineNr = { fg = colors.lavender },
-		DiagnosticVirtualTextError = { bg = colors.none },
-		DiagnosticVirtualTextWarn = { bg = colors.none },
-		DiagnosticVirtualTextInfo = { bg = colors.none },
-		DiagnosticVirtualTextHint = { bg = colors.none },
-	}
-}
-```
-
-## Usage with :set background
-
-The following autocmd will change the flavour to latte when you `:set background=light` and to mocha after `:set background=dark`
-
-```lua
-vim.api.nvim_create_autocmd("OptionSet", {
-	pattern = "background",
-	callback = function()
-		vim.cmd("Catppuccin " .. (vim.v.option_new == "light" and "latte" or "mocha"))
-	end,
-})
-```
-
-For people who are hybrid between light and dark mode!
-
-## Old catppuccin remap function
-
-Unlike the `:highlight` command which can update a highlight group, this function completely replaces the definition. (`:h nvim_set_hl`)
-
-```lua
-require("catppuccin.lib.highlighter").syntax({
-	Normal = { style = { "italic", "bold" } }
-})
-
-```
-
-If you wish to use the old highlight api (slower):
-
-```lua
-local function syntax(tbl)
-	for group, color in pairs(tbl) do
-		if color.style then
-			color.style = table.concat(color.style, ",")
-		end
-		local style = color.style and "gui=" .. color.style or "gui=NONE"
-		local fg = color.fg and "guifg=" .. color.fg or "guifg=NONE"
-		local bg = color.bg and "guibg=" .. color.bg or "guibg=NONE"
-		local sp = color.sp and "guisp=" .. color.sp or ""
-		local blend = color.blend and "blend=" .. color.blend or ""
-		local hl = "highlight " .. group .. " " .. style .. " " .. fg .. " " .. bg .. " " .. sp .. " " .. blend
-		vim.cmd(hl)
-		if color.link then
-			vim.cmd("highlight! link " .. group .. " " .. color.link)
-		end
-	end
-end
-
-syntax {
-	Normal = { style = { "italic", "bold" } },
-}
-```
-
-## Abnormal colors
-
-You need to enable [truecolor](https://wiki.archlinux.org/title/Color_output_in_console#True_color_support)
-
-Related: [:h termguicolors](https://neovim.io/doc/user/options.html#'termguicolors'), [catppuccin/nvim#182](https://github.com/catppuccin/nvim/issues/182),
-
-# 💝 Thanks to
-
--   [Pocco81](https://github.com/Pocco81)
--   [Null Chilly](https://github.com/nullchilly)
-
-<!-- panvimdoc-ignore-start -->
-
-&nbsp;
-
-<p align="center"><img src="https://raw.githubusercontent.com/catppuccin/catppuccin/main/assets/footers/gray0_ctp_on_line.svg?sanitize=true" /></p>
-<p align="center">Copyright &copy; 2021-present <a href="https://github.com/catppuccin" target="_blank">Catppuccin Org</a>
-<p align="center"><a href="https://github.com/catppuccin/catppuccin/blob/main/LICENSE"><img src="https://img.shields.io/static/v1.svg?style=for-the-badge&label=License&message=MIT&logoColor=d9e0ee&colorA=363a4f&colorB=b7bdf8"/></a></p>
-
-<!-- panvimdoc-ignore-end -->


### PR DESCRIPTION
As a user, I think it's easier to look through the integrations in alphabetical order rather than chronological order in which support was added in catppuccin, especially if you're new to the colorscheme, or wondering, "Does this support my favorite plugins?"