### PR TITLE
Add `WhichKeyBorder` highlight group

### DIFF
--- a/lua/catppuccin/groups/integrations/which_key.lua
+++ b/lua/catppuccin/groups/integrations/which_key.lua
@@ -6,7 +6,6 @@ function M.get()
 		WhichKeyGroup = { fg = cp.blue },
 		WhichKeyDesc = { fg = cp.pink },
 		WhichKeySeperator = { fg = cp.overlay0 },
-		WhichKeySeparator = { fg = cp.overlay0 },
 		WhichKeyFloat = { bg = cp.crust },
 		WhichKeyValue = { fg = cp.overlay0 },
 	}

--- a/lua/catppuccin/groups/integrations/which_key.lua
+++ b/lua/catppuccin/groups/integrations/which_key.lua
@@ -4,9 +4,10 @@ function M.get()
 	return {
 		WhichKey = { fg = cp.flamingo },
 		WhichKeyGroup = { fg = cp.blue },
-		WhichKeyDesc = { fg = cp.pink },
 		WhichKeySeperator = { fg = cp.overlay0 },
+		WhichKeyDesc = { fg = cp.pink },
 		WhichKeyFloat = { bg = cp.crust },
+		WhichKeyBorder = { fg = cp.blue },
 		WhichKeyValue = { fg = cp.overlay0 },
 	}
 end


### PR DESCRIPTION
Hi, catppuccin/nvim!

A new highlight group has been added to `which-key.nvim`.  (https://github.com/folke/which-key.nvim/commit/9c190ea91939eba8c2d45660127e0403a5300b5a)

This PR adds a new group and further removes unnecessary duplication.