### PR TITLE
fix(CI): Broken formatting workflow (ELF not found).

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: JohnnyMorganz/stylua-action@1.0.0
+      - uses: JohnnyMorganz/stylua-action@v1.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --check --config-path=stylua.toml .


### PR DESCRIPTION
This commit fixed the problem with formatting CI. Currently incorrect artifact was chosen due to the introduction of `linux-aarch64` artifacts of latest `stylua-action` _(a.k.a, `v1.1.0`)_, which would cause "ELF not found" related errors.
> Ref: https://github.com/JohnnyMorganz/stylua-action/releases/tag/v1.1.1