### PR TITLE
style: restore .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# EditorConfig is awesome: https://EditorConfig.org
+
+root = true
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+
+[*.txt]
+indent_style = tab
+indent_size = 4
+
+[*.{diff,md}]
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,12 +9,10 @@ root = true
 end_of_line = lf
 charset = utf-8
 insert_final_newline = true
-indent_style = tab
-indent_size = 4
 
-[*.txt]
+[*.lua]
 indent_style = tab
-indent_size = 4
 
 [*.{diff,md}]
 trim_trailing_whitespace = false
+indent_style = space


### PR DESCRIPTION
Restores .editorconfig with the following changes

- Remove indent size
- Mandate tabs only for lua
