### PR TITLE
feat(treesitter): add highlighting for ruby symbols

### DIFF
--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -108,6 +108,9 @@ function M.get()
 
 			-- yaml
 			["@field.yaml"] = { fg = cp.blue }, -- For fields.
+
+			-- Ruby
+			["@symbol"] = { fg = cp.flamingo },
 		}
 	else -- neovim <= 0.7.2
 		return {


### PR DESCRIPTION
https://github.com/catppuccin/nvim/commit/bb805c5fd6149b62e64861f13caa85b40d279a44 broke highlighting for ruby symbols. 

This is because in tree-sitter integration there were no support for ruby symbols.

- Before
<img width="350" alt="Screenshot 2022-09-27 at 21 01 26" src="https://user-images.githubusercontent.com/45797239/192614378-530e5610-2a39-4cf6-b9be-ae407d59ac26.png">

- After
<img width="423" alt="Screenshot 2022-09-27 at 21 04 50" src="https://user-images.githubusercontent.com/45797239/192614387-4890ff1d-1781-4379-9b8b-7f3a4b5e503f.png">
