### PR TITLE
Add FAQ Section for TrueColor

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,11 +830,17 @@ require("nvim-treesitter.configs").setup {
 }
 ```
 
-## Setup for macOS "Terminal.app"
+## Colors doesn't match preview screenshots
 
-Trick question - not possible! Catppuccin requires TrueColor, which macOS's
-native "Terminal.app" does not support. Consider using
-[iTerm2](https://iterm2.com/) as an alternative terminal emulator.
+Catppuccin requires true color support AKA terminals support the full range of 16 million colors
+
+- Supported: iterm2 (macOS), kitty, wezterm, alacritty, tmux, ...
+
+Full list of support terminals can be found here: https://github.com/termstandard/colors#truecolor-support-in-output-devices
+
+- Unsupported terminal: Terminal.app (macOS), Terminus, Terminology, ...
+
+Full list of Unsupported terminals can be found here: https://github.com/termstandard/colors#not-supporting-truecolor
 
 # Thanks to
 

--- a/README.md
+++ b/README.md
@@ -830,6 +830,12 @@ require("nvim-treesitter.configs").setup {
 }
 ```
 
+## Setup for macOS "Terminal.app"
+
+Trick question - not possible! Catppuccin requires TrueColor, which macOS's
+native "Terminal.app" does not support. Consider using
+[iTerm2](https://iterm2.com/) as an alternative terminal emulator.
+
 # Thanks to
 
 -   [Pocco81](https://github.com/Pocco81)


### PR DESCRIPTION
macOS's "Terminal.app" does not support TrueColor. It can be tricky to identify
what's going wrong when users encounter this issue. Hopefully this will point
them in the right direction by identifying that Terminal.app doesn't have the
color support that catppuccin requires.
