### PR TITLE
fix(neotree): better popup style in transparent background

### DIFF
--- a/lua/catppuccin/groups/integrations/neotree.lua
+++ b/lua/catppuccin/groups/integrations/neotree.lua
@@ -21,6 +21,9 @@ function M.get()
 		NeoTreeGitUntracked = { fg = cp.blue },
 		NeoTreeGitStaged = { fg = cp.green },
 
+		NeoTreeFloatBorder = { fg = cp.blue },
+		NeoTreeFloatTitle = { fg = cp.subtext0 },
+
 		NeoTreeFileNameOpened = { fg = cp.pink },
 		NeoTreeDimText = { fg = cp.overlay1 },
 		NeoTreeFilterTerm = { fg = cp.green, style = { "bold" } },


### PR DESCRIPTION
Before:
<img width="642" alt="WeChat4a6b9ba95fceace5841f9feea74d4990" src="https://user-images.githubusercontent.com/54089360/194686051-c8ad7481-8de8-4262-b686-4bb6a1f61f48.png">

After:
<img width="764" alt="WeChat9a34fce2ecbecd0a3fb594c8e9b4a3cc" src="https://user-images.githubusercontent.com/54089360/194686063-dd9ab08f-a0e2-4b5e-b300-3a3a8ac354ac.png">
