### PR TITLE
fix(gitsigns): preview_hunk respect transparency

### DIFF
--- a/lua/catppuccin/groups/integrations/gitsigns.lua
+++ b/lua/catppuccin/groups/integrations/gitsigns.lua
@@ -5,6 +5,9 @@ function M.get()
 		GitSignsAdd = { fg = cp.green }, -- diff mode: Added line |diff.txt|
 		GitSignsChange = { fg = cp.yellow }, -- diff mode: Changed line |diff.txt|
 		GitSignsDelete = { fg = cp.red }, -- diff mode: Deleted line |diff.txt|
+
+		GitSignsAddPreview = cnf.transparent_background and { fg = cp.green, bg = cp.none } or { link = "DiffAdd" },
+		GitSignsDeletePreview = cnf.transparent_background and { fg = cp.red, bg = cp.none } or { link = "DiffDelete" },
 	}
 end
 


### PR DESCRIPTION
gitsigns preview_hunk respect transparency
<img width="923" alt="image" src="https://user-images.githubusercontent.com/54089360/196845742-c2f00dc2-1466-480c-b4bd-f55d17064352.png">
