### PR TITLE
fix(bufferline): add tab separator highlight

### DIFF
--- a/lua/catppuccin/groups/integrations/bufferline.lua
+++ b/lua/catppuccin/groups/integrations/bufferline.lua
@@ -32,7 +32,10 @@ function M.get(user_config)
 			duplicate = { fg = cp.surface1, bg = inactive_bg, style = styles },
 			-- tabs
 			tab = { fg = cp.surface1, bg = inactive_bg },
-			tab_selected = { fg = cp.sky, bg = active_bg },
+			tab_selected = { fg = cp.sky, bg = active_bg, bold = true },
+			tab_separator = { fg = separator_fg, bg = inactive_bg },
+			tab_separator_selected = { fg = cp.maroon, bg = active_bg },
+
 			tab_close = { fg = cp.red, bg = inactive_bg },
 			indicator_selected = { fg = cp.peach, bg = active_bg, style = styles },
 			-- separators


### PR DESCRIPTION
renderings:
Frappe
<img width="1439" alt="WeChata1c9ccc47487a7e42fac328b9f1b824c" src="https://user-images.githubusercontent.com/54089360/198001971-4d7aaa19-f8ae-4b5e-b057-1dcb45503702.png">

transparency
<img width="1436" alt="WeChat3dd0a24d14a89a6b5eaf5bb50c40d29a" src="https://user-images.githubusercontent.com/54089360/198002013-d692d2af-6d5b-426a-ac3a-6cc31031c4fb.png">
