### PR TITLE
Added Felines new provider: macro and search count

### DIFF
--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -269,6 +269,7 @@ function M.get()
 	-- macro
 	components.active[1][12] = {
 		provider = "macro",
+		enabled = function() return vim.api.nvim_get_option "cmdheight" == 0 end,
 		hl = {
 			fg = sett.extras,
 			bg = sett.bkg,
@@ -279,6 +280,7 @@ function M.get()
 	-- search count
 	components.active[1][13] = {
 		provider = "search_count",
+		enabled = function() return vim.api.nvim_get_option "cmdheight" == 0 end,
 		hl = {
 			fg = sett.extras,
 			bg = sett.bkg,

--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -265,7 +265,7 @@ function M.get()
 		},
 		left_sep = invi_sep,
 	}
-	
+
 	-- macro
 	components.active[1][12] = {
 		provider = "macro",
@@ -275,7 +275,7 @@ function M.get()
 		},
 		left_sep = invi_sep,
 	}
-	
+
 	-- search count
 	components.active[1][13] = {
 		provider = "search_count",
@@ -285,9 +285,7 @@ function M.get()
 		},
 		left_sep = invi_sep,
 	}
-	
 	-- Extras ------>
-	
 
 	-- ######## Left
 

--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -265,7 +265,29 @@ function M.get()
 		},
 		left_sep = invi_sep,
 	}
+	
+	-- macro
+	components.active[1][12] = {
+		provider = "macro",
+		hl = {
+			fg = sett.extras,
+			bg = sett.bkg,
+		},
+		left_sep = invi_sep,
+	}
+	
+	-- search count
+	components.active[1][13] = {
+		provider = "search_count",
+		hl = {
+			fg = sett.extras,
+			bg = sett.bkg,
+		},
+		left_sep = invi_sep,
+	}
+	
 	-- Extras ------>
+	
 
 	-- ######## Left
 


### PR DESCRIPTION
Feline added new providers for macro recordings and search count.
This is useful if `cmdline=0`. By pressing `qa...` it's shows the recording next to the *position* component. Same for the search count. 
If you don't like the position of the two components, feel free to position them elsewhere.

<img width="372" alt="macro" src="https://user-images.githubusercontent.com/39212564/198098535-93ab6c15-8392-4f7f-98ae-f455200efd29.png">

<img width="560" alt="search_count" src="https://user-images.githubusercontent.com/39212564/198098580-f4941d15-a2b1-48b6-aa9c-2a26abbe8215.png">
