### PR TITLE
fix(lsp): LspInfo border color

### DIFF
--- a/lua/catppuccin/groups/integrations/native_lsp.lua
+++ b/lua/catppuccin/groups/integrations/native_lsp.lua
@@ -84,6 +84,7 @@ function M.get()
 		LspDiagnosticsUnderlineInformation = { style = underlines.information, sp = info }, -- Used to underline "Information" diagnostics
 		LspDiagnosticsUnderlineHint = { style = underlines.hints, sp = hint }, -- Used to underline "Hint" diagnostics
 		LspCodeLens = { fg = cp.overlay0 }, -- virtual text of the codelens
+		LspInfoBorder = { fg = cp.blue }, -- LspInfo border
 	}
 end
 


### PR DESCRIPTION
Fix the LspInfo border color.

Before:
![Screenshot 2022-11-12 at 15 31 44](https://user-images.githubusercontent.com/23206205/201462971-0e81465e-13c9-4e32-93b6-aebd2480a911.png)

After:
![Screenshot 2022-11-12 at 15 32 03](https://user-images.githubusercontent.com/23206205/201462980-7108b5b3-11a1-49a7-8e65-1f25d116f175.png)
