### PR TITLE
feat(mini.nvim): better tabline integration with underline support

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -60,7 +60,7 @@ function M.get()
 		StatusLineNC = { fg = cp.surface1, bg = cnf.transparent_background and cp.none or cp.mantle }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
 		TabLine = { bg = cp.mantle, fg = cp.surface1 }, -- tab pages line, not active tab page label
 		TabLineFill = { bg = cp.black }, -- tab pages line, where there are no labels
-		TabLineSel = { fg = cp.green, bg = cp.surface1 }, -- tab pages line, active tab page label
+		TabLineSel = { bg = cp.pink }, -- tab pages line, active tab page label
 		Title = { fg = cp.blue, style = { "bold" } }, -- titles for output from ":set all", ":autocmd" etcp.
 		Visual = { bg = cp.surface1, style = { "bold" } }, -- Visual mode selection
 		VisualNOS = { bg = cp.surface1, style = { "bold" } }, -- Visual mode selection when vim is "Not Owning the Selection".

--- a/lua/catppuccin/groups/integrations/mini.lua
+++ b/lua/catppuccin/groups/integrations/mini.lua
@@ -42,14 +42,14 @@ function M.get()
 
 		MiniSurround = { bg = cp.pink, fg = cp.surface1 },
 
-		MiniTablineCurrent = { fg = cp.text, bg = cp.base, style = { "bold", "italic" } },
+		MiniTablineCurrent = { fg = cp.text, bg = cp.base, sp = cp.red, style = { "bold", "italic", "underline" } },
 		MiniTablineFill = { bg = bg_highlight },
 		MiniTablineHidden = { fg = cp.text, bg = inactive_bg },
-		MiniTablineModifiedCurrent = { fg = cp.base, bg = cp.text, style = { "bold", "italic" } },
-		MiniTablineModifiedHidden = { fg = inactive_bg, bg = cp.text },
-		MiniTablineModifiedVisible = { fg = cp.surface1, bg = cp.subtext1 },
+		MiniTablineModifiedCurrent = { fg = cp.red, bg = cp.none, style = { "bold", "italic" } },
+		MiniTablineModifiedHidden = { fg = cp.red, bg = cp.none },
+		MiniTablineModifiedVisible = { fg = cp.red, bg = cp.none },
 		MiniTablineTabpagesection = { fg = cp.surface1, bg = cp.base },
-		MiniTablineVisible = { fg = cp.subtext1, bg = cp.surface1 },
+		MiniTablineVisible = { bg = cp.none },
 
 		MiniTestEmphasis = { style = { "bold" } },
 		MiniTestFail = { fg = cp.red, style = { "bold" } },


### PR DESCRIPTION
Hi, I made this pr for better `mini.tabline` integration. This will add **underline** under current buffer, also I added some small fixes related to background which look quite off to the colorscheme.

<img width="539" alt="Screen Shot 2022-11-13 at 3 30 55 pm" src="https://user-images.githubusercontent.com/1514823/201505804-818ddce0-288e-4102-8a65-cbd3298adbc2.png">

Thank you!