### PR TITLE
fix(nix): no longer stuck in 1969

### DIFF
--- a/lua/catppuccin/lib/vim/init.lua
+++ b/lua/catppuccin/lib/vim/init.lua
@@ -10,14 +10,6 @@ vim.fn.stdpath = function(what)
 	end
 end
 
-vim.loop = {
-	fs_stat = function(file)
-		local mod = vim.fn.getftime(file)
-		if mod == -1 then return nil end
-		return { mtime = { sec = mod } }
-	end,
-}
-
 -- Reference: https://github.com/neovim/neovim/blob/master/runtime/lua/vim/shared.lua
 local function tbl_isempty(t)
 	assert(type(t) == "table", string.format("Expected table, got %s", type(t)))


### PR DESCRIPTION
cc @EdenEast

1. Hash user and git file name when `mtime = 1` (Which means nix is presented)

2. viml's getftime is faster than uv.fs_stat

```lua
local now = vim.loop.hrtime
local start = now()
for _ = 1, 10000 do
	vim.fn.getftime "/home/nullchilly/.cache/nvim/catppuccin/date.txt"
end
print("getftime  " .. (now() - start) / 1000000 .. "ms")

start = now()
for _ = 1, 10000 do
	vim.loop.fs_stat "/home/nullchilly/.cache/nvim/catppuccin/date.txt"
end
print("luajit    " .. (now() - start) / 1000000 .. "ms")
```

```lua
getftime  7.314094ms                                                                           
luajit    16.374475ms
```

Closes #348