### PR TITLE
Fix: @type.qualifier color pink according to examples

### DIFF
--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -69,7 +69,8 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@type"] = { link = "Type" }, -- For types.
 		["@type.builtin"] = { fg = C.yellow, style = O.styles.properties or "italic" }, -- For builtin types.
 		["@type.definition"] = { link = "@type" }, -- type definitions (e.g. `typedef` in C)
-		["@type.qualifier"] = { fg = C.pink, style = O.styles.properties }, -- type qualifiers (e.g. `const`)
+		["@type.qualifier"] = { link = "@type" }, -- type qualifiers (e.g. `const`)
+		["@type.qualifier.php"] = { fg = C.pink, style = O.styles.properties }, -- type qualifiers (e.g. `const`)
 
 		["@storageclass"] = { link = "StorageClass" }, -- visibility/life-time/etc. modifiers (e.g. `static`)
 		["@attribute"] = { link = "Constant" }, -- attribute annotations (e.g. Python decorators)

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -69,7 +69,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@type"] = { link = "Type" }, -- For types.
 		["@type.builtin"] = { fg = C.yellow, style = O.styles.properties or "italic" }, -- For builtin types.
 		["@type.definition"] = { link = "@type" }, -- type definitions (e.g. `typedef` in C)
-		["@type.qualifier"] = { link = "@type" }, -- type qualifiers (e.g. `const`)
+		["@type.qualifier"] = { fg = C.pink, style = O.styles.properties }, -- type qualifiers (e.g. `const`)
 
 		["@storageclass"] = { link = "StorageClass" }, -- visibility/life-time/etc. modifiers (e.g. `static`)
 		["@attribute"] = { link = "Constant" }, -- attribute annotations (e.g. Python decorators)

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -70,7 +70,6 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@type.builtin"] = { fg = C.yellow, style = O.styles.properties or "italic" }, -- For builtin types.
 		["@type.definition"] = { link = "@type" }, -- type definitions (e.g. `typedef` in C)
 		["@type.qualifier"] = { link = "@type" }, -- type qualifiers (e.g. `const`)
-		["@type.qualifier.php"] = { fg = C.pink, style = O.styles.properties }, -- type qualifiers (e.g. `const`)
 
 		["@storageclass"] = { link = "StorageClass" }, -- visibility/life-time/etc. modifiers (e.g. `static`)
 		["@attribute"] = { link = "Constant" }, -- attribute annotations (e.g. Python decorators)
@@ -154,6 +153,9 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Ruby
 		["@symbol.ruby"] = { fg = C.flamingo },
+
+		-- PHP
+		["@type.qualifier.php"] = { fg = C.pink, style = O.styles.properties }, -- type qualifiers (e.g. `const`)
 	}
 end
 


### PR DESCRIPTION
Ever since [this commit](https://github.com/nvim-treesitter/nvim-treesitter/commit/0f866c15b4e77406c3eb4110e7ddbabce52ccaa1) in treesitter's git repo. The colors in my PHP files look off. Private / protected / public keywords in classes are now yellow and do not really fit its surrounding colors. I am not sure if this yellow is the intended color for Catppuccin's theme, because if I look at examples / images these keywords are usually pink; for example in [this image](https://preview.redd.it/2zwg74ym3n381.png?width=1327&format=png&auto=webp&s=f2a4e2f466be53bed6deee97de0831b452863a0a). Pink fits better, because it will not make these keywords stand out as much.

I have the impression that this pink color is the intended one for these keywords. If I am mistaken and the keywords are yellow on purpose, then close the PR, and I will change it myself in the config.