### PR TITLE
fix(symbols_outline): remove FocusedSymbol bg

### DIFF
--- a/lua/catppuccin/groups/integrations/symbols_outline.lua
+++ b/lua/catppuccin/groups/integrations/symbols_outline.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.get()
 	return {
-		FocusedSymbol = { fg = C.yellow, bg = C.base },
+		FocusedSymbol = { fg = C.yellow, bg = C.none },
 	}
 end
 


### PR DESCRIPTION
Looks nicer when cursorline is set.

Before:
![Screenshot 2022-11-29 at 14 14 23](https://user-images.githubusercontent.com/23206205/204452927-3ed2ab3c-7783-4b3c-8764-e5a0cce9b02e.png)

After:
![Screenshot 2022-11-29 at 14 13 24](https://user-images.githubusercontent.com/23206205/204452755-23263a47-1a0b-4865-aee9-f7e7095a98af.png)
