### PR TITLE
fix(syntax): lack of foreground text for `@text.todo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ require("catppuccin").setup {
         return {
             Comment = { fg = colors.flamingo },
             ["@constant.builtin"] = { fg = colors.peach, style = {} },
-            ["@comment"] = { fg = colors.surface2, style = { "italic" }
+            ["@comment"] = { fg = colors.surface2, style = { "italic" } },
         }
     end
 }

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -103,7 +103,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@text.environment.name"] = { fg = C.blue }, -- text indicating the type of an environment
 		["@text.reference"] = { fg = C.lavender, style = { "bold" } }, -- references
 
-		["@text.todo"] = { bg = C.yellow }, -- todo notes
+		["@text.todo"] = { fg = C.base, bg = C.yellow }, -- todo notes
 		["@text.note"] = { fg = C.base, bg = C.blue },
 		["@text.warning"] = { fg = C.base, bg = C.yellow },
 		["@text.danger"] = { fg = C.base, bg = C.red },


### PR DESCRIPTION
`@text.todo` was lacking a foreground color so it would take the colour from the comment - this in the latte theme lead to a pretty nasty grey-on-orange theme. Compared to the other types like `@text.danger`, it seems we're missing the `fg` property which this PR sets.

As a drive-by change, I also added a missing brace in the example code for overrides in `README.md`.

Here's an example of the issue:

<img width="455" alt="Screenshot 2022-11-29 at 16 06 24" src="https://user-images.githubusercontent.com/193238/204582023-b7e1eadf-c142-41a5-b692-1a744caf86db.png">
