### PR TITLE
fix(neotest): consistency with original theme

### DIFF
--- a/lua/catppuccin/groups/integrations/neotest.lua
+++ b/lua/catppuccin/groups/integrations/neotest.lua
@@ -11,7 +11,7 @@ function M.get()
 		NeotestFocused = { style = { "bold", "underline" } },
 		NeotestFile = { fg = C.blue },
 		NeotestDir = { fg = C.blue },
-		NeotestIndent = { fg = C.surface0 },
+		NeotestIndent = { fg = C.overlay1 },
 		NeotestExpandMarker = { fg = C.overlay1 },
 		NeotestAdapterName = { fg = C.maroon },
 		NeotestWinSelect = { fg = C.blue, style = { "bold" } },


### PR DESCRIPTION
Original neotest's theme:
![image](https://user-images.githubusercontent.com/84649544/205447171-32a21aff-86c8-4779-9311-c957a1ac3d0a.png)
Current catppuccin integration:
![image](https://user-images.githubusercontent.com/84649544/205447279-120042d4-674d-4de7-80a0-1b5068eb409b.png)
With this PR:
![image](https://user-images.githubusercontent.com/84649544/205447223-51787590-2406-4639-aaf1-349fe8361c46.png)
