### PR TITLE
feat(lualine): add a specific color for the terminal mode

### DIFF
--- a/lua/lualine/themes/catppuccin.lua
+++ b/lua/lualine/themes/catppuccin.lua
@@ -15,6 +15,11 @@ catppuccin.insert = {
 	b = { bg = C.surface1, fg = C.teal },
 }
 
+catppuccin.terminal = {
+	a = { bg = C.green, fg = C.base, gui = "bold" },
+	b = { bg = C.surface1, fg = C.teal },
+}
+
 catppuccin.command = {
 	a = { bg = C.peach, fg = C.base, gui = "bold" },
 	b = { bg = C.surface1, fg = C.peach },


### PR DESCRIPTION
The default color of the `terminal` mode in lualine is the same as the `normal` mode,
specify a color for the terminal mode to recognize whether the mode is either `terminal`
or `normal`.