### PR TITLE
Explicitly convert value to string

### DIFF
--- a/lua/catppuccin/lib/compiler.lua
+++ b/lua/catppuccin/lib/compiler.lua
@@ -9,7 +9,7 @@ local function inspect(t)
 	local list = {}
 	for k, v in pairs(t) do
 		local q = type(v) == "string" and [["]] or ""
-		table.insert(list, fmt([[%s = %s%s%s]], k, q, v, q))
+		table.insert(list, fmt([[%s = %s%s%s]], k, q, tostring(v), q))
 	end
 	return fmt([[{ %s }]], table.concat(list, ", "))
 end


### PR DESCRIPTION
This fixes an error in neovim v0.9:
bad argument #4 to 'fmt' (string expected, got boolean)

🎉 First off, thanks for taking the time to contribute! 🎉 Here are some guidelines from us:
- Format code using [stylua](https://github.com/johnnymorganz/stylua).
- New plugin integration should be added in [alphabetical order](https://github.com/catppuccin/nvim#integrations)
- Recommendation:
  - Create a topic branch on your fork for your specific PR.
  - Consider using [conventionalcommits.org's](https://www.conventionalcommits.org/en/v1.0.0/) rules for creating explicit and meaningful commit messages.
  - If it's your first time contributing to a project then read [About pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) on Github's docs.