### PR TITLE
fix(nvimtree) replace deprecated highlight-group

### DIFF
--- a/lua/catppuccin/groups/integrations/nvimtree.lua
+++ b/lua/catppuccin/groups/integrations/nvimtree.lua
@@ -8,7 +8,10 @@ function M.get()
 		NvimTreeOpenedFolderName = { fg = C.blue },
 		NvimTreeEmptyFolderName = { fg = C.blue },
 		NvimTreeIndentMarker = { fg = C.overlay0 },
-		NvimTreeVertSplit = { fg = C.base, bg = O.transparent_background and C.none or C.base },
+		NvimTreeWinSeparator = {
+			fg = O.transparent_background and C.surface1 or C.base,
+			bg = O.transparent_background and C.none or C.base,
+		},
 		NvimTreeRootFolder = { fg = C.lavender, style = { "bold" } },
 		NvimTreeSymlink = { fg = C.pink },
 		NvimTreeStatuslineNc = { fg = C.mantle, bg = C.mantle },


### PR DESCRIPTION
The `NvimTreeVertSplit` highlight group has been deprecated in favor of `NvimTreeWinSeparator`, more about this: https://github.com/nvim-tree/nvim-tree.lua/pull/1225

When used this highlight group with `transparent_background = false` there is a line next to NvimTree:
![20221226_20h34m55s_grim](https://user-images.githubusercontent.com/53343401/209599426-096507bb-5f86-4412-9ba5-2452d141fe53.png)

With the changes of this PR it looks like this:
![20221226_20h27m10s_grim](https://user-images.githubusercontent.com/53343401/209599887-5ed0b5d0-61b1-4575-8c84-0035bb835859.png)
