### PR TITLE
feat(neogit): add notification highlight groups

### DIFF
--- a/lua/catppuccin/groups/integrations/neogit.lua
+++ b/lua/catppuccin/groups/integrations/neogit.lua
@@ -36,6 +36,9 @@ function M.get()
 			bg = U.darken(C.blue, 0.300, C.base),
 			fg = U.lighten(C.blue, 0.800, C.text),
 		},
+		NeogitNotificationInfo = { fg = C.blue },
+		NeogitNotificationWarning = { fg = C.yellow },
+		NeogitNotificationError = { fg = C.red },
 	}
 end
 


### PR DESCRIPTION
add [notification highlighting](https://github.com/TimUntersberger/neogit#notification-highlighting) for neogit, same color as [notify](https://github.com/rcarriga/nvim-notify) integration.

before(info notification has inconsistent green color):
![before](https://user-images.githubusercontent.com/28292229/210744211-8653d8df-77cf-4f66-b616-ecbdacf589bd.png)

after:
![info](https://user-images.githubusercontent.com/28292229/210876280-78fb8b5a-e03d-4a2b-8daa-3b8d3d0092f5.png)

![error](https://user-images.githubusercontent.com/28292229/210876312-bea24204-96dd-413c-ad22-71192810320b.png)

