### PR TITLE
fix(lsp_trouble): incorrect highlight group names

### DIFF
--- a/lua/catppuccin/groups/integrations/lsp_trouble.lua
+++ b/lua/catppuccin/groups/integrations/lsp_trouble.lua
@@ -2,9 +2,9 @@ local M = {}
 
 function M.get()
 	return {
-		LspTroubleText = { fg = C.green },
-		LspTroubleCount = { fg = C.pink, bg = C.surface1 },
-		LspTroubleNormal = { fg = C.text, bg = C.crust },
+		TroubleText = { fg = C.green },
+		TroubleCount = { fg = C.pink, bg = C.surface1 },
+		TroubleNormal = { fg = C.text, bg = C.crust },
 	}
 end
 


### PR DESCRIPTION
uh, just a little fix highlight group names

**before**: 
![maim-20230113_232737](https://user-images.githubusercontent.com/49778014/212372770-078541fc-6d2e-41e8-8d1b-5b95daa37ebf.png)

**after**:
![maim-20230113_232427](https://user-images.githubusercontent.com/49778014/212372700-70b10884-ffd6-474a-a920-fc5f4f4b2bd1.png)
