### PR TITLE
fix hidden special integrations in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ integrations = {
   }
 }
 ```
+</details>
 
 <details> <summary>bufferline.nvim</summary>
 


### PR DESCRIPTION
Some special integrations are hidden in the README due to a small typo, this fixes it.