### PR TITLE
fix(load): flavour mechanism

### DIFF
--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -80,17 +80,14 @@ function M.compile()
 	M.flavour = _flavour -- Restore user flavour after compile
 end
 
----@param default? string
 local function get_flavour(default)
 	local flavour
 	if default then
 		flavour = default
-	elseif vim.g.colors_name == "catppuccin" then
-		-- after first time load
+	elseif vim.g.colors_name == "catppuccin" then -- after first time load
 		flavour = M.options.background[is_vim and vim.eval "&background" or vim.o.background]
 	else
-		-- first time load
-		flavour = M.flavour
+		flavour = M.flavour -- first time load
 	end
 
 	if flavour and not M.flavours[flavour] then
@@ -108,7 +105,6 @@ end
 
 local lock = false -- Avoid g:colors_name reloading
 
----@param flavour? string
 function M.load(flavour)
 	if lock then return end
 	M.flavour = get_flavour(flavour)
@@ -157,23 +153,16 @@ end
 
 if is_vim then return M end
 
-vim.api.nvim_create_user_command("Catppuccin", function(inp)
-	if not M.flavours[inp.args] then
-		vim.notify(
-			"Catppuccin (error): Invalid flavour '"
-				.. inp.args
-				.. "', flavour must be 'latte', 'frappe', 'macchiato' or 'mocha'",
-			vim.log.levels.ERROR
-		)
-		return
-	end
-	vim.api.nvim_command("colorscheme catppuccin-" .. inp.args)
-end, {
-	nargs = 1,
-	complete = function(line)
-		return vim.tbl_filter(function(val) return vim.startswith(val, line) end, vim.tbl_keys(M.flavours))
-	end,
-})
+vim.api.nvim_create_user_command(
+	"Catppuccin",
+	function(inp) vim.api.nvim_command("colorscheme catppuccin-" .. get_flavour(inp.args)) end,
+	{
+		nargs = 1,
+		complete = function(line)
+			return vim.tbl_filter(function(val) return vim.startswith(val, line) end, vim.tbl_keys(M.flavours))
+		end,
+	}
+)
 
 vim.api.nvim_create_user_command("CatppuccinCompile", function()
 	for name, _ in pairs(package.loaded) do
@@ -183,4 +172,5 @@ vim.api.nvim_create_user_command("CatppuccinCompile", function()
 	vim.notify("Catppuccin (info): compiled cache!", vim.log.levels.INFO)
 	vim.api.nvim_command "colorscheme catppuccin"
 end, {})
+
 return M

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -84,21 +84,24 @@ end
 local function get_flavour(flavour)
 	if flavour and not M.flavours[flavour] then
 		vim.notify(
-			string.format("Catppuccin (error): Invalid flavour '%s', flavour must be 'latte', 'frappe', 'macchiato' or 'mocha'", flavour),
+			string.format(
+				"Catppuccin (error): Invalid flavour '%s', flavour must be 'latte', 'frappe', 'macchiato' or 'mocha'",
+				flavour
+			),
 			vim.log.levels.ERROR
 		)
-    flavour = "mocha"
+		flavour = "mocha"
 	end
 
-  if flavour then
-    return flavour
-  elseif vim.g.colors_name and vim.g.colors_name == "catppuccin" then
-    -- after first time load
-    return M.options.background[is_vim and vim.eval "&background" or vim.o.background]
-  else
-    -- first time load
-    return M.flavour or "mocha"
-  end
+	if flavour then
+		return flavour
+	elseif vim.g.colors_name and vim.g.colors_name == "catppuccin" then
+		-- after first time load
+		return M.options.background[is_vim and vim.eval "&background" or vim.o.background]
+	else
+		-- first time load
+		return M.flavour or "mocha"
+	end
 end
 
 local lock = false -- Avoid g:colors_name reloading
@@ -114,7 +117,7 @@ function M.load(flavour)
 		M.compile()
 		f = loadfile(compiled_path)
 	end
-  ---@diagnostic disable-next-line: need-check-nil
+	---@diagnostic disable-next-line: need-check-nil
 	f()
 	lock = false
 end

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -80,8 +80,19 @@ function M.compile()
 	M.flavour = _flavour -- Restore user flavour after compile
 end
 
----@param flavour? string
-local function get_flavour(flavour)
+---@param default? string
+local function get_flavour(default)
+  local flavour
+	if default then
+		flavour = default
+	elseif vim.g.colors_name and vim.g.colors_name == "catppuccin" then
+		-- after first time load
+		flavour = M.options.background[is_vim and vim.eval "&background" or vim.o.background]
+	else
+		-- first time load
+		flavour = M.flavour
+	end
+
 	if flavour and not M.flavours[flavour] then
 		vim.notify(
 			string.format(
@@ -90,18 +101,9 @@ local function get_flavour(flavour)
 			),
 			vim.log.levels.ERROR
 		)
-		flavour = "mocha"
+		flavour = nil
 	end
-
-	if flavour then
-		return flavour
-	elseif vim.g.colors_name and vim.g.colors_name == "catppuccin" then
-		-- after first time load
-		return M.options.background[is_vim and vim.eval "&background" or vim.o.background]
-	else
-		-- first time load
-		return M.flavour or "mocha"
-	end
+  return flavour or "mocha"
 end
 
 local lock = false -- Avoid g:colors_name reloading

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -85,7 +85,7 @@ local function get_flavour(default)
 	local flavour
 	if default then
 		flavour = default
-	elseif vim.g.colors_name and vim.g.colors_name == "catppuccin" then
+	elseif vim.g.colors_name == "catppuccin" then
 		-- after first time load
 		flavour = M.options.background[is_vim and vim.eval "&background" or vim.o.background]
 	else

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -82,7 +82,7 @@ end
 
 ---@param default? string
 local function get_flavour(default)
-  local flavour
+	local flavour
 	if default then
 		flavour = default
 	elseif vim.g.colors_name and vim.g.colors_name == "catppuccin" then
@@ -103,7 +103,7 @@ local function get_flavour(default)
 		)
 		flavour = nil
 	end
-  return flavour or "mocha"
+	return flavour or "mocha"
 end
 
 local lock = false -- Avoid g:colors_name reloading


### PR DESCRIPTION
Tested:
- Set colorscheme when g:colors_name is present (Hence the lock check)
  - whether g:colors_name == "catppuccin" initially
- Respect o:background
- Change flavour
- Respect User default flavour

Resolve: https://github.com/catppuccin/nvim/pull/380