### PR TITLE
feat(lspsaga): Add support for latest highlight groups

### DIFF
--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -707,7 +707,6 @@ For custom Lsp Kind Icon and Color
 >lua
     require("lspsaga").setup {
         ui = {
-            colors = require("catppuccin.groups.integrations.lsp_saga").custom_colors(),
             kind = require("catppuccin.groups.integrations.lsp_saga").custom_kind(),
         },
     }

--- a/lua/catppuccin/groups/integrations/lsp_saga.lua
+++ b/lua/catppuccin/groups/integrations/lsp_saga.lua
@@ -1,23 +1,5 @@
 local M = {}
 
-function M.custom_colors()
-	local C = require("catppuccin.palettes").get_palette()
-	return {
-		normal_bg = C.base,
-		title_bg = C.green,
-		red = C.red,
-		magenta = C.maroon,
-		orange = C.peach,
-		yellow = C.yellow,
-		green = C.green,
-		cyan = C.sky,
-		blue = C.blue,
-		purple = C.mauve,
-		white = C.text,
-		black = C.crust,
-	}
-end
-
 function M.custom_kind()
 	local C = require("catppuccin.palettes").get_palette()
 	return {
@@ -54,6 +36,35 @@ function M.custom_kind()
 	}
 end
 
-function M.get() return {} end
+function M.get()
+	return {
+		TitleString = { fg = C.text },
+		TitleIcon = { fg = C.blue },
+		SagaBorder = { fg = C.blue, bg = C.none },
+		SagaNormal = { bg = O.transparent_background and C.none or C.base },
+		SagaExpand = { fg = C.green },
+		SagaCollapse = { fg = C.green },
+		SagaBeacon = { bg = U.darken(C.surface0, 0.8, C.crust) },
+		ActionPreviewTitle = { fg = C.mauve, bg = O.transparent_background and C.none or C.base },
+		CodeActionText = { fg = C.green },
+		CodeActionNumber = { fg = C.pink },
+		FinderSelection = { fg = C.blue, style = { "bold" } },
+		FinderFileName = { fg = C.text },
+		FinderIcon = { fg = C.flamingo },
+		FinderCount = { fg = C.lavender },
+		FinderType = { fg = C.flamingo },
+		FinderSpinnerTitle = { fg = C.mauve, style = { "bold" } },
+		FinderSpinner = { fg = C.mauve, style = { "bold" } },
+		FinderVirtText = { fg = C.overlay2 },
+		RenameNormal = { fg = C.text },
+		DiagnosticSource = { fg = C.overlay0 },
+		DiagnosticPos = { fg = C.surface2 },
+		DiagnosticWord = { fg = C.text },
+		CallHierarchyIcon = { fg = C.mauve },
+		CallHierarchyTitle = { fg = C.blue },
+		SagaShadow = { bg = C.crust },
+		OutlineIndent = { fg = C.overlay2 },
+	}
+end
 
 return M


### PR DESCRIPTION
This commit makes `catppuccin` compatible with `lspsaga`@v0.2.4. It added support for the latest highlight groups.

Major highlight groups have been adapted to stay harmonic with other integrations _(to the best of my ability)_. The default values for some highlight groups are just ok, so I didn't append them to the list.

<sup>Minor fixes:</sup>
<sup>\* Custom colors are no longer supported, so they have been removed.</sup>