### PR TITLE
feat: add vim-sandwich integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Below is a list of supported plugins and their corresponding integration module.
 | [vim-clap](https://github.com/liuchengxu/vim-clap)                                    | Special             |
 | [vim-gitgutter](https://github.com/airblade/vim-gitgutter)                            | gitgutter           |
 | [vim-illuminate](https://github.com/RRethy/vim-illuminate)                            | illuminate          |
+| [vim-sandwich](https://github.com/machakann/vim-sandwich)                             | sandwich            |
 | [vim-sneak](https://github.com/justinmk/vim-sneak)                                    | vim_sneak           |
 | [vimwiki](https://github.com/vimwiki/vimwiki)                                         | vimwiki             |
 | [which-key.nvim](https://github.com/folke/which-key.nvim)                             | which_key           |
@@ -411,6 +412,7 @@ require("catppuccin").setup({
         nvimtree = true,
         overseer = false,
         pounce = false,
+        sandwich = false,
         semantic_tokens = false,
         symbols_outline = false,
         telekasten = false,

--- a/lua/catppuccin/groups/integrations/sandwich.lua
+++ b/lua/catppuccin/groups/integrations/sandwich.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+function M.get()
+	return {
+		OperatorSandwichAdd = { bg = C.blue, fg = C.base },
+		OperatorSandwichBuns = { bg = C.blue, fg = C.base },
+		OperatorSandwichChange = { bg = C.blue, fg = C.base },
+		OperatorSandwichDelete = { bg = C.blue, fg = C.base },
+	}
+end
+
+return M


### PR DESCRIPTION
Hello,
This is a simple but vital sandwich integration ^^
The highlights are very subtle and invisible on the cursor line.
In my opinion one color is enough for all groups so I've chosen the blue, is it ok ?

![image](https://user-images.githubusercontent.com/90783310/218283551-c3636fa0-e9cc-4aa2-bdc8-96ac6d016dbd.png)

![image](https://user-images.githubusercontent.com/90783310/218284522-d9fe3a7d-c1ac-4f9a-824e-4a2e22169804.png)

![image](https://user-images.githubusercontent.com/90783310/218284488-df6a8f71-b931-4d03-991d-7a3178d19d64.png)
