### PR TITLE
fix(transparent): winblend and popup

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -38,9 +38,12 @@ function M.get()
 				or C.base,
 		}, -- normal text in non-current windows
 		NormalSB = { fg = C.text, bg = C.crust }, -- normal text in non-current windows
-		NormalFloat = { fg = C.text, bg = O.transparent_background and C.none or C.mantle }, -- Normal text in floating windows.
+		NormalFloat = { fg = C.text, bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle }, -- Normal text in floating windows.
 		FloatBorder = { fg = C.blue },
-		Pmenu = { bg = O.transparent_background and C.none or U.darken(C.surface0, 0.8, C.crust), fg = C.overlay2 }, -- Popup menu: normal item.
+		Pmenu = {
+			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or U.darken(C.surface0, 0.8, C.crust),
+			fg = C.overlay2,
+		}, -- Popup menu: normal item.
 		PmenuSel = { fg = C.text, bg = C.surface1, style = { "bold" } }, -- Popup menu: selected item.
 		PmenuSbar = { bg = C.surface1 }, -- Popup menu: scrollbar.
 		PmenuThumb = { bg = C.overlay0 }, -- Popup menu: Thumb of the scrollbar.

--- a/lua/catppuccin/groups/integrations/noice.lua
+++ b/lua/catppuccin/groups/integrations/noice.lua
@@ -7,23 +7,10 @@ function M.get()
 		NoiceCmdline = { fg = C.text },
 		NoiceCmdlineIcon = { fg = C.sky, style = virtual_text.information },
 		NoiceCmdlineIconSearch = { fg = C.yellow },
-		NoiceCmdlinePopup = { fg = C.text, bg = O.transparent_background and C.none or C.base },
 		NoiceCmdlinePopupBorder = { fg = C.lavender },
 		NoiceCmdlinePopupBorderSearch = { fg = C.yellow },
-		NoiceConfirm = { fg = C.text, bg = O.transparent_background and C.none or C.base },
 		NoiceConfirmBorder = { fg = C.blue },
 		NoiceMini = { fg = C.text },
-		NoicePopup = { fg = C.text, bg = O.transparent_background and C.none or C.mantle },
-		NoicePopupBorder = { link = "FloatBorder" },
-		NoicePopupmenu = { link = "Pmenu" },
-		NoicePopupmenuBorder = { link = "FloatBorder" },
-		NoicePopupmenuMatch = { link = "Special" },
-		NoicePopupmenuSelected = { link = "PmenuSel" },
-		NoiceScrollbar = { link = "PmenuSbar" },
-		NoiceScrollbarThumb = { link = "PmenuThumb" },
-		NoiceSplit = { fg = C.text, bg = O.transparent_background and C.none or C.mantle },
-		NoiceSplitBorder = { link = "FloatBorder" },
-		NoiceVirtualText = { link = "DiagnosticVirtualTextInfo" },
 	}
 end
 

--- a/lua/catppuccin/groups/integrations/which_key.lua
+++ b/lua/catppuccin/groups/integrations/which_key.lua
@@ -6,7 +6,6 @@ function M.get()
 		WhichKeyGroup = { fg = C.blue },
 		WhichKeySeperator = { fg = C.overlay0 },
 		WhichKeyDesc = { fg = C.pink },
-		WhichKeyFloat = { bg = O.transparent_background and C.none or C.crust },
 		WhichKeyBorder = { fg = C.blue },
 		WhichKeyValue = { fg = C.overlay0 },
 	}

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -139,7 +139,10 @@ function M.setup(user_conf)
 
 	local git_path = debug.getinfo(1).source:sub(2, -24) .. ".git" .. M.path_sep .. "ORIG_HEAD"
 	local git = vim.fn.getftime(git_path) -- 2x faster vim.loop.fs_stat
-	local hash = require("catppuccin.lib.hashing").hash(user_conf) .. (git == -1 and git_path or git) -- no .git in /nix/store -> cache path
+	local hash = require("catppuccin.lib.hashing").hash(user_conf)
+		.. (git == -1 and git_path or git) -- no .git in /nix/store -> cache path
+		.. (vim.o.winblend == 0 and 1 or 0) -- :h winblend
+		.. (vim.o.pumblend == 0 and 1 or 0) -- :h pumblend
 
 	if cached ~= hash then
 		M.compile()

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -85,7 +85,7 @@ local function get_flavour(default)
 	if default then
 		flavour = default
 	elseif vim.g.colors_name == "catppuccin" then -- after first time load
-		flavour = M.options.background[is_vim and vim.eval "&background" or vim.o.background]
+		flavour = M.options.background[vim.o.background]
 	else
 		flavour = M.flavour -- first time load
 	end

--- a/lua/catppuccin/lib/vim/compiler.lua
+++ b/lua/catppuccin/lib/vim/compiler.lua
@@ -17,7 +17,7 @@ endif
 set termguicolors
 let g:colors_name = "catppuccin"]],
 	}
-	table.insert(lines, "set background=" .. (flavour == "latte" and [["light"]] or [["dark"]]))
+	table.insert(lines, "set background=" .. (flavour == "latte" and [[light]] or [[dark]]))
 
 	local tbl = vim.tbl_deep_extend("keep", theme.custom_highlights, theme.integrations, theme.syntax, theme.editor)
 

--- a/lua/catppuccin/lib/vim/init.lua
+++ b/lua/catppuccin/lib/vim/init.lua
@@ -1,6 +1,12 @@
 -- TODO: private _G.vim
 vim.command [[command! CatppuccinCompile lua require('catppuccin').compile() print("Catppuccin (info): compiled cache!")]]
 
+vim.o = setmetatable({}, {
+	__index = function(_, k)
+		if k == "background" then return vim.eval "&background" end
+	end,
+})
+
 vim.fn.stdpath = function(what)
 	if what ~= "cache" then return end
 	if package.config:sub(1, 1) == "\\" then


### PR DESCRIPTION
fix #401

With `vim.o.winblend = 0` and `vim.o.pumblend = 0` (default value in neovim):

![image](https://user-images.githubusercontent.com/56817415/218323545-006604bc-ba6a-45c6-bf61-421ae92364e6.png)

With `vim.o.winblend = 50` and `vim.o.pumblend` = 50:

![image](https://user-images.githubusercontent.com/56817415/218323611-d0b8b98b-6f37-400a-9dca-3a81239bfee5.png)
