### PR TITLE
Fix: php theme methods

### DIFF
--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -169,7 +169,9 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@symbol.ruby"] = { fg = C.flamingo },
 
 		-- PHP
-		["@type.qualifier.php"] = { fg = C.pink, style = O.styles.properties }, -- type qualifiers (e.g. `const`)
+		["@type.qualifier.php"] = { link = "Keyword" }, -- type qualifiers (e.g. `const`)
+		["@method.php"] = { link = "Function" },
+		["@method.call.php"] = { link = "Function" },
 	}
 end
 

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -53,7 +53,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Keywords
 		["@keyword"] = { link = "Keyword" }, -- For keywords that don't fall in previous categories.
-		["@keyword.function"] = { fg = C.mauve, style = O.styles.keywords or {} }, -- For keywords used to define a fuction.
+		["@keyword.function"] = { fg = C.mauve, style = O.styles.keywords or {} }, -- For keywords used to define a function.
 		["@keyword.operator"] = { fg = C.mauve, style = O.styles.operators or {} }, -- For new keyword operator
 		["@keyword.return"] = { fg = C.mauve, style = O.styles.keywords or {} },
 		-- JS & derivative


### PR DESCRIPTION
I noticed a few weeks ago that my php theme changed. The methods in my classes became peach colored. I found out this change happened in [this commit](https://github.com/robmeijerink/nvim/commit/b17cfa01cf0517cc3614602df39e8433dc116fab). I figured this is by mistake, because [this reference](https://github.com/catppuccin/nvim/blob/main/lua/catppuccin/groups/syntax.lua#L14) states that method calls should have the same colors as functions. I restored the colors of methods in this PR to how they were before. I checked the rest of my php syntax and all the colors are back to normal again. Thanks for this great theme!