### PR TITLE
fix(compiler): remove `require` call to write compiled files

### DIFF
--- a/lua/catppuccin/lib/compiler.lua
+++ b/lua/catppuccin/lib/compiler.lua
@@ -18,7 +18,7 @@ function M.compile(flavour)
 	local theme = require("catppuccin.lib.mapper").apply(flavour)
 	local lines = {
 		[[
-require("catppuccin").compiled = string.dump(function()
+return string.dump(function()
 if vim.g.colors_name then vim.cmd("hi clear") end
 vim.o.termguicolors = true
 vim.g.colors_name = "catppuccin"]],
@@ -71,10 +71,9 @@ Below is the error message that we captured:
 		dofile(err_path)
 		return
 	end
-	f()
 
 	if file then
-		file:write(require("catppuccin").compiled)
+		file:write(f())
 		file:close()
 	else
 		print(

--- a/lua/catppuccin/lib/compiler.lua
+++ b/lua/catppuccin/lib/compiler.lua
@@ -52,9 +52,15 @@ vim.g.colors_name = "catppuccin"]],
 	if vim.fn.isdirectory(O.compile_path) == 0 then vim.fn.mkdir(O.compile_path, "p") end
 	local file = io.open(O.compile_path .. path_sep .. flavour .. "_compiled.lua", "wb")
 
+	if vim.g.catppuccin_debug then -- Debugging purpose
+		local deb = io.open((path_sep == "/" and "/tmp" or os.getenv "TMP") .. "/catppuccin_debug.lua", "wb")
+		deb:write(table.concat(lines, "\n"))
+		deb:close()
+	end
+
 	local f = loadstring(table.concat(lines, "\n"), "=")
 	if not f then
-		local err_path = (path_sep == "/" and "/tmp" or os.getenv "TMP") .. "/catppuccin_error.lua"
+		local err_path = (path_sep == "/" and "/tmp" or os.getenv "TMP") .. "/catppuccin_debug.lua"
 		print(string.format(
 			[[Catppuccin (error): Most likely some mistake made in your catppuccin config
 You can open %s for debugging

--- a/lua/catppuccin/lib/vim/compiler.lua
+++ b/lua/catppuccin/lib/vim/compiler.lua
@@ -9,7 +9,7 @@ function M.compile(flavour)
 	local theme = require("catppuccin.lib.mapper").apply(flavour)
 	local lines = {
 		[[
-require("catppuccin").compiled = string.dump(function()
+return string.dump(function()
 vim.command[[
 if exists("colors_name")
 	hi clear
@@ -80,10 +80,9 @@ Below is the error message that we captured:
 		dofile(err_path)
 		return
 	end
-	f()
 
 	if file then
-		file:write(require("catppuccin").compiled)
+		file:write(f())
 		file:close()
 	else
 		print(


### PR DESCRIPTION
This pr cleans up the compiler and removes the requirement to save the compiled file to `require('catppuccin').compiled` and read back again.