### PR TITLE
feat(nvim-ts-rainbow2): add support for ts-rainbow2

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Below is a list of supported plugins and their corresponding integration module.
 | ------------------------------------------------------------------------------------- | ------------------- |
 | [aerial.nvim](https://github.com/stevearc/aerial.nvim)                                | aerial              |
 | [barbar.nvim](https://github.com/romgrk/barbar.nvim)                                  | barbar              |
-| [barbecue.nvim](https://github.com/utilyre/barbecue.nvim)                             | barbecue, Special             |
+| [barbecue.nvim](https://github.com/utilyre/barbecue.nvim)                             | barbecue, Special   |
 | [beacon.nvim](https://github.com/DanilaMihailov/beacon.nvim)                          | beacon              |
 | [bufferline.nvim](https://github.com/akinsho/bufferline.nvim)                         | Special             |
 | [dashboard-nvim](https://github.com/glepnir/dashboard-nvim)                           | dashboard           |
@@ -352,7 +352,7 @@ Below is a list of supported plugins and their corresponding integration module.
 | [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) | treesitter_context  |
 | [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)                 | treesitter          |
 | [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)                            | ts_rainbow          |
-| [nvim-ts-rainbow2](https://github.com/HiPhish/nvim-ts-rainbow2)                       | ts_rainbow          |
+| [nvim-ts-rainbow2](https://github.com/HiPhish/nvim-ts-rainbow2)                       | ts_rainbow2         |
 | [overseer.nvim](https://github.com/stevearc/overseer.nvim)                            | overseer            |
 | [pounce.nvim](https://github.com/rlane/pounce.nvim)                                   | pounce              |
 | [symbols-outline.nvim](https://github.com/simrat39/symbols-outline.nvim)              | symbols_outline     |

--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Below is a list of supported plugins and their corresponding integration module.
 | [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) | treesitter_context  |
 | [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)                 | treesitter          |
 | [nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)                            | ts_rainbow          |
+| [nvim-ts-rainbow2](https://github.com/HiPhish/nvim-ts-rainbow2)                       | ts_rainbow          |
 | [overseer.nvim](https://github.com/stevearc/overseer.nvim)                            | overseer            |
 | [pounce.nvim](https://github.com/rlane/pounce.nvim)                                   | pounce              |
 | [symbols-outline.nvim](https://github.com/simrat39/symbols-outline.nvim)              | symbols_outline     |
@@ -420,6 +421,7 @@ require("catppuccin").setup({
         treesitter = true,
         treesitter_context = false,
         ts_rainbow = false,
+        ts_rainbow2 = false,
         vim_sneak = false,
         vimwiki = false,
         which_key = false,

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -366,6 +366,7 @@ module. (See Special integrations
 │nvim-treesitter-context <https://github.com/nvim-treesitter/nvim-treesitter-context>│treesitter_context │
 │nvim-treesitter <https://github.com/nvim-treesitter/nvim-treesitter>                │treesitter         │
 │nvim-ts-rainbow <https://github.com/p00f/nvim-ts-rainbow>                           │ts_rainbow         │
+│nvim-ts-rainbow2 <https://github.com/HiPhish/nvim-ts-rainbow2>                      │ts_rainbow2        │
 │overseer.nvim <https://github.com/stevearc/overseer.nvim>                           │overseer           │
 │pounce.nvim <https://github.com/rlane/pounce.nvim>                                  │pounce             │
 │symbols-outline.nvim <https://github.com/simrat39/symbols-outline.nvim>             │symbols_outline    │
@@ -444,6 +445,7 @@ Click here to see an example config
             treesitter = true,
             treesitter_context = false,
             ts_rainbow = false,
+            ts_rainbow2 = false,
             vim_sneak = false,
             vimwiki = false,
             which_key = false,

--- a/lua/catppuccin/groups/integrations/ts_rainbow2.lua
+++ b/lua/catppuccin/groups/integrations/ts_rainbow2.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+function M.get()
+	return {
+		TSRainbowRed = { fg = C.red },
+		TSRainbowYellow = { fg = C.yellow },
+		TSRainbowBlue = { fg = C.blue },
+		TSRainbowOrange = { fg = C.peach },
+		TSRainbowGreen = { fg = C.green },
+		TSRainbowViolet = { fg = C.mauve },
+		TSRainbowCyan = { fg = C.teal },
+	}
+end
+
+return M

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -41,6 +41,7 @@ local M = {
 			telescope = true,
 			treesitter = not is_vim,
 			ts_rainbow = true,
+			ts_rainbow2 = true,
 			barbecue = {
 				dim_dirname = true,
 			},


### PR DESCRIPTION
[nvim-ts-rainbow](https://github.com/p00f/nvim-ts-rainbow)  is no longer maintained.
[nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) recommend [nvim-ts-rainbow2](https://github.com/HiPhish/nvim-ts-rainbow2) in its wiki [Extra modules and plugins](https://github.com/nvim-treesitter/nvim-treesitter/wiki/Extra-modules-and-plugins).
So, I add support for it based on nvim-ts-rainbow
![图片](https://user-images.githubusercontent.com/56501688/218944305-7efbf1c5-bfc8-44a8-b83d-5371b5845d24.png)
