### PR TITLE
fix(load): remove o:background reload workaround

### DIFF
--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -104,13 +104,9 @@ local function get_flavour(default)
 	return flavour or M.options.background[vim.o.background]
 end
 
-local lock = false -- Avoid g:colors_name reloading
-
 function M.load(flavour)
-	if lock then return end
 	M.flavour = get_flavour(flavour)
 	local compiled_path = M.options.compile_path .. M.path_sep .. M.flavour
-	lock = true
 	local f = loadfile(compiled_path)
 	if not f then
 		M.compile()
@@ -118,7 +114,6 @@ function M.load(flavour)
 	end
 	---@diagnostic disable-next-line: need-check-nil
 	f()
-	lock = false
 end
 
 function M.setup(user_conf)

--- a/lua/catppuccin/lib/compiler.lua
+++ b/lua/catppuccin/lib/compiler.lua
@@ -23,13 +23,17 @@ end
 function M.compile(flavour)
 	local theme = require("catppuccin.lib.mapper").apply(flavour)
 	local lines = {
-		[[
+		string.format(
+			[[
 return string.dump(function()
-if vim.g.colors_name then vim.cmd("hi clear") end
 vim.o.termguicolors = true
-vim.g.colors_name = "catppuccin"]],
+if vim.g.colors_name then vim.cmd("hi clear") end
+vim.o.background = "%s"
+vim.g.colors_name = "catppuccin"
+local h = vim.api.nvim_set_hl]],
+			flavour == "latte" and "light" or "dark"
+		),
 	}
-	table.insert(lines, "vim.o.background = " .. (flavour == "latte" and [["light"]] or [["dark"]]))
 	if path_sep == "\\" then O.compile_path = O.compile_path:gsub("/", "\\") end
 
 	local tbl = vim.tbl_deep_extend("keep", theme.custom_highlights, theme.integrations, theme.syntax, theme.editor)
@@ -52,9 +56,9 @@ vim.g.colors_name = "catppuccin"]],
 		if color.link and (theme.custom_highlights[group] and not theme.custom_highlights[group].link) then
 			color.link = nil
 		end
-		table.insert(lines, fmt([[vim.api.nvim_set_hl(0, "%s", %s)]], group, inspect(color)))
+		table.insert(lines, fmt([[h(0, "%s", %s)]], group, inspect(color)))
 	end
-	table.insert(lines, "end)")
+	table.insert(lines, "end, true)")
 	if vim.fn.isdirectory(O.compile_path) == 0 then vim.fn.mkdir(O.compile_path, "p") end
 	local file = io.open(O.compile_path .. path_sep .. flavour, "wb")
 
@@ -64,7 +68,7 @@ vim.g.colors_name = "catppuccin"]],
 		deb:close()
 	end
 
-	local f = loadstring(table.concat(lines, "\n"), "=")
+	local f = loadstring(table.concat(lines, "\n"))
 	if not f then
 		local err_path = (path_sep == "/" and "/tmp" or os.getenv "TMP") .. "/catppuccin_error.lua"
 		print(string.format(

--- a/lua/catppuccin/lib/vim/compiler.lua
+++ b/lua/catppuccin/lib/vim/compiler.lua
@@ -8,16 +8,19 @@ local fmt = string.format
 function M.compile(flavour)
 	local theme = require("catppuccin.lib.mapper").apply(flavour)
 	local lines = {
-		[[
+		string.format(
+			[[
 return string.dump(function()
 vim.command[[
 if exists("colors_name")
 	hi clear
 endif
 set termguicolors
+set background=%s
 let g:colors_name = "catppuccin"]],
+			(flavour == "latte" and "light" or "dark")
+		),
 	}
-	table.insert(lines, "set background=" .. (flavour == "latte" and [[light]] or [[dark]]))
 
 	local tbl = vim.tbl_deep_extend("keep", theme.custom_highlights, theme.integrations, theme.syntax, theme.editor)
 
@@ -57,7 +60,7 @@ let g:colors_name = "catppuccin"]],
 			)
 		end
 	end
-	table.insert(lines, "]]end)")
+	table.insert(lines, "]]end, true)")
 	if vim.fn.isdirectory(O.compile_path) == 0 then vim.fn.mkdir(O.compile_path, "p") end
 	local file = io.open(O.compile_path .. path_sep .. flavour, "wb")
 	local ls = load or loadstring
@@ -68,7 +71,7 @@ let g:colors_name = "catppuccin"]],
 		deb:close()
 	end
 
-	local f = ls(table.concat(lines, "\n"), "=")
+	local f = ls(table.concat(lines, "\n"))
 	if not f then
 		local err_path = (path_sep == "/" and "/tmp" or os.getenv "TMP") .. "/catppuccin_error.lua"
 		print(string.format(


### PR DESCRIPTION
- If `g:colors_name` was set then `:set background=dark/light` will trigger `ColorScheme` autocmd. We can replace the `lock` mechanism simply by setting `o:background` before `g:colors_name`

- We compiled to bytecode using `string.dump(f)` and then load with `loadstring(str, "=")` to strip the debug infos. A better way (to save binary size) would be `string.dump(f, true)` which strip the debug info and then load with `loadstring(str)`

- `local h = nvim.api.nvim_set_hl` was introduced to further strip the bytecode size.