### PR TITLE
feat: add support for new lsp semantic token highlight groups

### DIFF
--- a/lua/catppuccin/groups/integrations/semantic_tokens.lua
+++ b/lua/catppuccin/groups/integrations/semantic_tokens.lua
@@ -2,41 +2,6 @@ local M = {}
 
 function M.get()
 	return {
-		LspNamespace = { fg = C.blue, style = { "italic" } },
-		LspType = { fg = C.yellow, style = O.styles.types or {} },
-		LspClass = { fg = C.mauve, style = O.styles.keywords or {} },
-		-- LspEnum = {},
-		-- LspInterface =
-		LspStruct = { fg = C.sapphire },
-		LspTypeParameter = { fg = C.yellow, style = O.styles.types or {} }, -- For types.
-
-		LspParameter = { fg = C.maroon, style = { "italic" } }, -- For parameters of a function.
-
-		LspVariable = { fg = C.text, style = O.styles.variables or {} },
-		LspProperty = { fg = C.teal, style = O.styles.properties or {} },
-		-- LspEnumMember =
-		-- LspEvent =
-		LspFunction = { fg = C.blue, style = O.styles.functions or {} },
-		LspMethod = { fg = C.blue, style = O.styles.functions or {} }, -- For method calls and definitions.
-		LspMacro = { fg = C.teal, style = O.styles.functions or {} },
-		LspKeyword = { fg = C.mauve, style = O.styles.keywords or {} },
-		-- LspModifier =
-		LspComment = { fg = C.surface2, style = O.styles.comments },
-		LspString = { fg = C.green, style = O.styles.strings or {} },
-		LspNumber = { fg = C.peach, style = O.styles.numbers or {} },
-		-- LspRegexp =
-		LspOperator = { fg = C.sky, style = O.styles.operators or {} },
-		-- LspDeclaration =
-		-- LspDefinition =
-		-- LspReadonly =
-		-- LspStatic =
-		LspDeprecated = { fg = C.surface2, style = { "strikethrough" } },
-		-- LspAbstract =
-		-- LspAsync =
-		-- LspModification =
-		-- LspDocumentation =
-		-- LspDefaultLibrary =
-
 		["@lsp.type.enum"] = { link = "@type" },
 		["@lsp.type.keyword"] = { link = "@keyword" },
 		["@lsp.type.interface"] = { link = "@interface" },

--- a/lua/catppuccin/groups/integrations/semantic_tokens.lua
+++ b/lua/catppuccin/groups/integrations/semantic_tokens.lua
@@ -36,6 +36,16 @@ function M.get()
 		-- LspModification =
 		-- LspDocumentation =
 		-- LspDefaultLibrary =
+
+		["@lsp.type.enum"] = { link = "@type" },
+		["@lsp.type.keyword"] = { link = "@keyword" },
+		["@lsp.type.interface"] = { link = "@interface" },
+		["@lsp.type.namespace"] = { link = "@namespace" },
+		["@lsp.type.parameter"] = { link = "@parameter" },
+		["@lsp.type.property"] = { link = "@property" },
+		["@lsp.type.variable"] = {}, -- use treesitter styles for regular variables
+		["@lsp.typemod.function.defaultLibrary"] = { link = "Special" },
+		["@lsp.typemod.variable.defaultLibrary"] = { link = "@variable.builtin" },
 	}
 end
 

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -64,6 +64,7 @@ local M = {
 					information = { "underline" },
 				},
 			},
+			semantic_tokens = vim.fn.has "nvim-0.9" == 1,
 		},
 		color_overrides = {},
 		highlight_overrides = {},

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -64,7 +64,7 @@ local M = {
 					information = { "underline" },
 				},
 			},
-			semantic_tokens = vim.fn.has "nvim-0.9" == 1,
+			semantic_tokens = true,
 		},
 		color_overrides = {},
 		highlight_overrides = {},


### PR DESCRIPTION
Highlighting on nightly is **broken** right now, because of neovim/neovim#22022.

This PR is basically just recent commits from folke/tokyonight.nvim.

This needs to be tested, bc I'm not sure if I didn't break anything.
