### PR TITLE
feat(editor): better matchparen highlight

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -23,7 +23,7 @@ function M.get()
 		Substitute = { bg = C.surface1, fg = U.vary_color({ latte = C.red }, C.pink) }, -- |:substitute| replacement text highlighting
 		LineNr = { fg = C.surface1 }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is seC.
 		CursorLineNr = { fg = C.lavender }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line. highlights the number in numberline.
-		MatchParen = { fg = C.peach, style = { "bold" } }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
+		MatchParen = { fg = C.peach, bg = C.surface1, style = { "bold" } }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
 		ModeMsg = { fg = C.text, style = { "bold" } }, -- 'showmode' message (e.g., "-- INSERT -- ")
 		-- MsgArea = { fg = C.text }, -- Area for messages and cmdline, don't set this highlight because of https://github.com/neovim/neovim/issues/17832
 		MsgSeparator = {}, -- Separator for scrolled messages, `msgsep` flag of 'display'


### PR DESCRIPTION
Since rainbow parentheses are widely used, I highly recommend changing the `bg` for `MatchParen`, so that the highlight is better able to distinguish from rainbow colors.

before

![image](https://user-images.githubusercontent.com/61115159/224522506-f3c50378-5886-46ac-b6b7-ed7c669d5c6d.png)


after:

![image](https://user-images.githubusercontent.com/61115159/224522450-6f921284-52e4-42cd-9201-f2c2beba1d34.png)
