### PR TITLE
fix(editor): revert matchparen highlight

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -23,7 +23,7 @@ function M.get()
 		Substitute = { bg = C.surface1, fg = U.vary_color({ latte = C.red }, C.pink) }, -- |:substitute| replacement text highlighting
 		LineNr = { fg = C.surface1 }, -- Line number for ":number" and ":#" commands, and when 'number' or 'relativenumber' option is seC.
 		CursorLineNr = { fg = C.lavender }, -- Like LineNr when 'cursorline' or 'relativenumber' is set for the cursor line. highlights the number in numberline.
-		MatchParen = { bg = C.surface1, style = { "bold" } }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
+		MatchParen = { fg = C.peach, bg = C.surface1, style = { "bold" } }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
 		ModeMsg = { fg = C.text, style = { "bold" } }, -- 'showmode' message (e.g., "-- INSERT -- ")
 		-- MsgArea = { fg = C.text }, -- Area for messages and cmdline, don't set this highlight because of https://github.com/neovim/neovim/issues/17832
 		MsgSeparator = {}, -- Separator for scrolled messages, `msgsep` flag of 'display'


### PR DESCRIPTION
Reverts catppuccin/nvim#430

I found out that normal bracket has grey fg over grey MatchParen bg isn't a good fit

![image](https://user-images.githubusercontent.com/56817415/224555292-12938924-8587-4f56-aa29-6475b872eee3.png)
![image](https://user-images.githubusercontent.com/56817415/224555517-e9b2882c-0922-4ef5-b7e8-e2c27afbd923.png)

This fits more
![image](https://user-images.githubusercontent.com/56817415/224555449-f19aa4cb-94aa-4038-95ce-c6fa23d78fd1.png)

![image](https://user-images.githubusercontent.com/56817415/224555545-f694dfcd-7f3d-4198-bbc2-47fd158d4e2c.png)
