### PR TITLE
feat(barbecue): add `bold_basename` and `dim_context` integration opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,8 @@ require("catppuccin").setup({
         -- Special integrations, see https://github.com/catppuccin/nvim#special-integrations
         barbecue = {
             dim_dirname = true,
+            bold_basename = true,
+            dim_context = false,
         },
         dap = {
             enabled = false,
@@ -487,6 +489,8 @@ The directory name color shown is dimmed by default, you can customize this sett
 integrations = {
   barbecue = {
     dim_dirname = true,
+    bold_basename = true,
+    dim_context = false,
   }
 }
 ```

--- a/lua/barbecue/theme/catppuccin.lua
+++ b/lua/barbecue/theme/catppuccin.lua
@@ -2,6 +2,8 @@ local C = require("catppuccin.palettes").get_palette()
 local O = require("catppuccin").options
 
 local dirname_color = O.integrations.barbecue.dim_dirname and C.overlay1 or C.text
+local basename_bold = O.integrations.barbecue.bold_basename
+local context_color = O.integrations.barbecue.dim_context and C.overlay1 or C.text
 
 local M = {
 	normal = { fg = C.text, bg = "none" },
@@ -11,8 +13,8 @@ local M = {
 	modified = { fg = C.peach },
 
 	dirname = { fg = dirname_color },
-	basename = { fg = C.text, bold = true },
-	context = { fg = C.text },
+	basename = { fg = C.text, bold = basename_bold },
+	context = { fg = context_color },
 
 	-- Same keys as navic
 	context_file = { fg = C.blue },

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -45,6 +45,8 @@ local M = {
 			ts_rainbow2 = true,
 			barbecue = {
 				dim_dirname = true,
+				bold_basename = true,
+				dim_context = false,
 			},
 			indent_blankline = {
 				enabled = true,


### PR DESCRIPTION
Hi! Thank you for this beautiful colorscheme.

This commit adds the following options to the barbecue integration:

* `bold_basename`: Configures whether the file name (basename) should be bold. [default: `true`]
* `dim_context`: Just like `dim_dirname` configures whether the context part should be dimmed. [default: `false`]

Also note that the defaults do _not_ change the way it currently looks, but rather make it more customizable.