### PR TITLE
feat: tweak headlines integration highlights

### DIFF
--- a/lua/catppuccin/groups/integrations/headlines.lua
+++ b/lua/catppuccin/groups/integrations/headlines.lua
@@ -2,15 +2,16 @@ local M = {}
 
 function M.get()
 	return {
-		Dash = { fg = C.peach, style = { "bold" } },
-		Quote = { fg = C.peach },
+		Dash = { fg = C.overlay2, style = { "bold" } },
+		Quote = { link = "@text.strong" },
 		CodeBlock = { bg = C.mantle },
-		Headline1 = { bg = C.green },
-		Headline2 = { bg = C.blue },
-		Headline3 = { bg = C.red },
-		Headline4 = { bg = C.mauve },
-		Headline5 = { bg = C.yellow },
-		Headline6 = { bg = C.lavender },
+		Headline = { link = "Headline1" },
+		Headline1 = { bg = C.surface0, fg = C.green },
+		Headline2 = { bg = C.surface0, fg = C.blue },
+		Headline3 = { bg = C.surface0, fg = C.red },
+		Headline4 = { bg = C.surface0, fg = C.mauve },
+		Headline5 = { bg = C.surface0, fg = C.yellow },
+		Headline6 = { bg = C.surface0, fg = C.lavender },
 	}
 end
 


### PR DESCRIPTION
5f6b5b29 introduced support for lukas-reineke/headlines.nvim, this changes a few of the highlights.

- sets the background to a neutral surface0 for Headlines
- sets their respective foreground colors
- sets the foreground for Dashes to a more neutral overlay2
- links Quote to "@text.strong"
- link "Headline" to "Headline1" in case there is no headline hierarchy for the current parser

Which fixes the concerns mentioned in https://github.com/catppuccin/nvim/issues/433#issuecomment-1481073933