### PR TITLE
Feature/improve floating window consistency

### DIFF
--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -516,7 +516,10 @@ Click here to see an example config ~
             ts_rainbow2 = false,
             vim_sneak = false,
             vimwiki = false,
-            which_key = false,
+            which_key = {
+                enabled = false,
+		border = false,
+	    },
     
             -- Special integrations, see https://github.com/catppuccin/nvim#special-integrations
             barbecue = {

--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -60,7 +60,7 @@ function M.get()
 		StatusLine = { fg = C.text, bg = O.transparent_background and C.none or C.mantle }, -- status line of current window
 		StatusLineNC = { fg = C.surface1, bg = O.transparent_background and C.none or C.mantle }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
 		TabLine = { bg = C.mantle, fg = C.surface1 }, -- tab pages line, not active tab page label
-		TabLineFill = { bg = C.black }, -- tab pages line, where there are no labels
+		TabLineFill = {}, -- tab pages line, where there are no labels
 		TabLineSel = { fg = C.green, bg = C.surface1 }, -- tab pages line, active tab page label
 		Title = { fg = C.blue, style = { "bold" } }, -- titles for output from ":set all", ":autocmd" etC.
 		Visual = { bg = C.surface1, style = { "bold" } }, -- Visual mode selection

--- a/lua/catppuccin/groups/integrations/cmp.lua
+++ b/lua/catppuccin/groups/integrations/cmp.lua
@@ -48,7 +48,7 @@ end
 function M.get_opts(opts)
   local cmp = O.integrations.cmp
 
-  if not helper.is_option_enabled(cmp) then
+  if not helper.is_option_enabled(cmp) and not helper.is_catppucin_selected() then
     return opts
   end
 

--- a/lua/catppuccin/groups/integrations/cmp.lua
+++ b/lua/catppuccin/groups/integrations/cmp.lua
@@ -1,5 +1,11 @@
 local M = {}
 
+local helper = require("catppuccin.lib.helper")
+local O = require("catppuccin").options
+
+local completion_border = helper.is_floating_border({auto = true})
+local documentation_border = helper.is_floating_border({auto = false})
+
 function M.get()
 	return {
 		CmpItemAbbr = { fg = C.overlay2 },
@@ -37,6 +43,39 @@ function M.get()
 		CmpItemKindTypeParameter = { fg = C.blue },
 		CmpItemKindCopilot = { fg = C.teal },
 	}
+end
+
+function M.get_opts(opts)
+  local cmp = O.integrations.cmp
+
+  if not helper.is_option_enabled(cmp) then
+    return opts
+  end
+
+  if type(cmp) == "table"
+    and cmp.border.completion ~= nil then
+    completion_border = cmp.border.completion
+  end
+
+  if type(cmp) == "table"
+    and cmp.border.documentation ~= nil then
+    documentation_border = cmp.border.documentation
+  end
+
+  local defaults = {
+    window = {
+      completion = {
+        border = completion_border and { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+        winhighlight = "FloatBorder:FloatBorder",
+      },
+      documentation = {
+        border = documentation_border and { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+        winhighlight = "FloatBorder:FloatBorder",
+      },
+    },
+  }
+
+  return vim.tbl_deep_extend("keep", opts or {}, defaults)
 end
 
 return M

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -1,8 +1,14 @@
 local M = {}
 
+local helper = require("catppuccin.lib.helper")
+local O = require("catppuccin").options
+
+local border = helper.is_floating_border({auto = true})
+
 function M.get()
-	return {
-		TelescopeBorder = { fg = C.blue },
+  local telescope = O.integrations.telescope
+
+  local opts = {
 		TelescopeSelectionCaret = { fg = C.flamingo },
 		TelescopeSelection = {
 			fg = O.transparent_background and C.flamingo or C.text,
@@ -10,17 +16,50 @@ function M.get()
 			style = { "bold" },
 		},
 		TelescopeMatching = { fg = C.blue },
-		-- TelescopePromptPrefix = { bg = C.crust },
-		-- TelescopePromptNormal = { bg = C.crust },
-		-- TelescopeResultsNormal = { bg = C.mantle },
-		-- TelescopePreviewNormal = { bg = C.crust },
-		-- TelescopePromptBorder = { bg = C.crust, fg = C.crust },
-		-- TelescopeResultsBorder = { bg = C.mantle, fg = C.crust },
-		-- TelescopePreviewBorder = { bg = C.crust, fg = C.crust },
-		-- TelescopePromptTitle = { fg = C.crust },
-		-- TelescopeResultsTitle = { fg = C.text },
-		-- TelescopePreviewTitle = { fg = C.crust },
-	}
+		TelescopeNormal = { bg = C.mantle },
+  }
+
+  if type(telescope) == "table"
+    and telescope.border ~= nil then
+    border = telescope.border
+  end
+
+  if border then
+    opts.TelescopeBorder = { default = true, link = "FloatBorder" }
+  else
+    opts.TelescopeBorder = { fg = C.mantle, bg = C.mantle }
+
+    opts.TelescopePromptTitle = { fg = C.base, bg = C.red }
+    opts.TelescopePromptBorder = { fg = C.surface0, bg = C.surface0 }
+    opts.TelescopePromptNormal = { bg = C.surface0 }
+
+    opts.TelescopeResultsTitle = { fg = C.base, bg = C.yellow }
+    opts.TelescopeResultsBorder = { fg = C.mantle, bg = C.mantle }
+    opts.TelescopeResultsNormal = { bg = C.mantle }
+
+    opts.TelescopePreviewTitle = { fg = C.base, bg = C.green }
+    opts.TelescopePreviewBorder = { fg = C.mantle, bg = C.mantle }
+    opts.TelescopePreviewNormal = { bg = C.mantle }
+  end
+
+  return opts
+end
+
+function M.get_opts(opts)
+  local telescope = O.integrations.telescope
+
+  if not helper.is_option_enabled(telescope) then
+    return opts
+  end
+
+  local defaults = {
+    defaults = {
+      border = true,
+      borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" }
+    }
+  }
+
+  return vim.tbl_deep_extend("keep", opts or {}, defaults)
 end
 
 return M

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -45,21 +45,4 @@ function M.get()
   return opts
 end
 
-function M.get_opts(opts)
-  local telescope = O.integrations.telescope
-
-  if not helper.is_option_enabled(telescope) then
-    return opts
-  end
-
-  local defaults = {
-    defaults = {
-      border = true,
-      borderchars = { "─", "│", "─", "│", "╭", "╮", "╯", "╰" }
-    }
-  }
-
-  return vim.tbl_deep_extend("keep", opts or {}, defaults)
-end
-
 return M

--- a/lua/catppuccin/groups/integrations/which_key.lua
+++ b/lua/catppuccin/groups/integrations/which_key.lua
@@ -6,35 +6,28 @@ local helper = require("catppuccin.lib.helper")
 local border = helper.is_floating_border({auto = false})
 
 function M.get()
-  return {
+  local which_key = O.integrations.which_key
+
+  local opts = {
 		WhichKey = { fg = C.flamingo },
 		WhichKeyGroup = { fg = C.blue },
 		WhichKeySeperator = { fg = C.overlay0 },
 		WhichKeyDesc = { fg = C.pink },
-    WhichKeyBorder = { default = true, link = "FloatBorder" },
 		WhichKeyValue = { fg = C.overlay0 },
 	}
-end
-
-function M.get_opts(opts)
-  local which_key = O.integrations.which_key
-
-  if not helper.is_option_enabled(which_key) then
-    return opts
-  end
 
   if type(which_key) == "table"
     and which_key.border ~= nil then
     border = which_key.border
   end
 
-  local defaults = {
-    window = {
-      border = border and "single" or "none", -- none, single, double, shadow
-    }
-  }
+  if border then
+    opts.WhichKeyBorder = { default = true, link = "FloatBorder" }
+  else
+    opts.WhichKeyBorder = { fg = C.none, bg = C.none }
+  end
 
-  return vim.tbl_deep_extend("keep", opts or {}, defaults)
+  return opts
 end
 
 return M

--- a/lua/catppuccin/groups/integrations/which_key.lua
+++ b/lua/catppuccin/groups/integrations/which_key.lua
@@ -1,14 +1,40 @@
 local M = {}
 
+local O = require("catppuccin").options
+local helper = require("catppuccin.lib.helper")
+
+local border = helper.is_floating_border({auto = false})
+
 function M.get()
-	return {
+  return {
 		WhichKey = { fg = C.flamingo },
 		WhichKeyGroup = { fg = C.blue },
 		WhichKeySeperator = { fg = C.overlay0 },
 		WhichKeyDesc = { fg = C.pink },
-		WhichKeyBorder = { fg = C.blue },
+    WhichKeyBorder = { default = true, link = "FloatBorder" },
 		WhichKeyValue = { fg = C.overlay0 },
 	}
+end
+
+function M.get_opts(opts)
+  local which_key = O.integrations.which_key
+
+  if not helper.is_option_enabled(which_key) then
+    return opts
+  end
+
+  if type(which_key) == "table"
+    and which_key.border ~= nil then
+    border = which_key.border
+  end
+
+  local defaults = {
+    window = {
+      border = border and "single" or "none", -- none, single, double, shadow
+    }
+  }
+
+  return vim.tbl_deep_extend("keep", opts or {}, defaults)
 end
 
 return M

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -11,6 +11,7 @@ local M = {
 		transparent_background = false,
 		show_end_of_buffer = false,
 		term_colors = false,
+    floating_border = "auto",
 		dim_inactive = {
 			enabled = false,
 			shade = "dark",

--- a/lua/catppuccin/lib/helper.lua
+++ b/lua/catppuccin/lib/helper.lua
@@ -1,0 +1,32 @@
+local M = {}
+
+local O = require("catppuccin").options
+
+function M.is_floating_border(opts)
+  local border = opts.auto or false;
+
+  if O.floating_border == "on" then
+    border = true
+  elseif O.floating_border == "off" then
+    border = false
+  end
+
+  return border
+end
+
+function M.is_option_enabled(opt)
+  if opt == nil then
+    return false
+  end
+
+  if type(opt) == "boolean" then
+    return opt
+  end
+
+  if type(opt) == "table" then
+    return opt.enabled
+  end
+
+end
+
+return M

--- a/lua/catppuccin/lib/helper.lua
+++ b/lua/catppuccin/lib/helper.lua
@@ -26,7 +26,10 @@ function M.is_option_enabled(opt)
   if type(opt) == "table" then
     return opt.enabled
   end
+end
 
+function M.is_catppucin_selected()
+  return vim.g.colors_name == "catppuccin"
 end
 
 return M


### PR DESCRIPTION
### Work in progress - Feedback is highly appreciated

1. Added a new catppuccin config: floating_border = "on", -- auto | on | off
This property controls the floating window border visibility across plugins.
The decision of which plugins have borders and which do not is made based on the default cappuccino config.

2. Added a new method "get_opts(opts)" in plugins: nvim-cmp, telescope and which-key.
This method needs to be used by the user to provide a default configuration base from catppuccin before configuring the actual plugin.
If the plugin is disabled in the catppuccin configuration, this method will act like a passthrough and will not add anything to the object used to configure the plugin.
The configuration provided by the user will be merged with the configuration provided by catppuccin. The user configuration will overwrite the catppucin provided config where the fields match.

3. Added the possibility to overwrite the global configuration for floating window border visibility by declaring per plugin settings in regards to having border visibility enabled or disabled.
The old config still works with the new code. No breaking changes due to config.

4. Linked plugin highlight group to theme FloatBorder highlight wherever possible.

In progress:
- fix lua style
- update documentation

Todo:
- update mason plugin

### Configs example
Catppuccin config:
```
require 'catppuccin'.setup({
  flavour = "mocha",
  -- flavour = "macchiato",
  -- flavour = "frappe",
  -- flavour = "latte",
  transparent_background = false,
  show_end_of_buffer = false,
  floating_border = "on",
  dim_inactive = {
    enabled = false,
    shade = "dark",
    percentage = 0.20,
  },
  integrations = {
    cmp = {
      enabled = true,
      border = {
        completion = true,
        documentation = true
      }
    },
    telescope = {
      enabled = true
    },
    which_key = {
      enabled = true
    },
  }
})
```

Cmp config:
```
require('nvim-cmp').setup(
  require("catppuccin.groups.integrations.cmp").get_opts({
    snippet = {
      expand = function(args)
        require('luasnip').lsp_expand(args.body) -- For `luasnip` users.
      end,
    },
    formatting = {
      format = lspkind.cmp_format({
        mode = 'symbol_text',
        menu = ({
          nvim_lsp = "[Lsp]",
          luasnip = "[Snip]",
          buffer = "[Buffer]",
          path = "[Path]",
        })
      }),
    },
    mapping = cmp.mapping.preset.insert({
      ['<C-b>'] = cmp.mapping.scroll_docs(-4),
      ['<C-f>'] = cmp.mapping.scroll_docs(4),
      ['<C-Space>'] = cmp.mapping.complete(),
      ['<C-e>'] = cmp.mapping.abort(),
      ['<CR>'] = cmp.mapping.confirm({ select = true }), -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
      ["<Tab>"] = cmp.mapping(function(fallback)
        if cmp.visible() then
          cmp.select_next_item()
        elseif luasnip.expand_or_jumpable() then
          luasnip.expand_or_jump()
        elseif has_words_before() then
          cmp.complete()
        else
          fallback()
        end
      end, { "i", "s" }),
      ["<S-Tab>"] = cmp.mapping(function(fallback)
        if cmp.visible() then
          cmp.select_prev_item()
        elseif luasnip.jumpable(-1) then
          luasnip.jump(-1)
        else
          fallback()
        end
      end, { "i", "s" }),
    }),
    sources = cmp.config.sources({
      { name = 'nvim_lsp' },
      { name = 'luasnip' }, -- For luasnip users.
      { name = 'buffer' },
      { name = 'path' },
    })
  })
)
```

Telescope config:
```
require('telescope').setup(
  require("catppuccin.groups.integrations.telescope").get_opts({
    defaults = {
      path_display = { "truncate" },
    }
  })
)
```

Which_key config:
```
require('which-key').setup (
  require "catppuccin.groups.integrations.which_key".get_opts({
    window = {
      -- border = "double", -- none, single, double, shadow
      margin = { 0, 0, 0, 0 }, -- extra window margin [top, right, bottom, left]
      padding = { 1, 1, 1, 1 }, -- extra window padding [top, right, bottom, left]
    }
  })
)
```



