### PR TITLE
feat: link FloatBorder and NormalFloat to catppuccin for which_key an…

### DIFF
--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.get()
 	return {
-    TelescopeNormal = { link = "NormalFloat"},
+		TelescopeNormal = { link = "NormalFloat" },
     TelescopeBorder = { link = "FloatBorder"},
     TelescopeSelectionCaret = { fg = C.flamingo },
 		TelescopeSelection = {

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -2,8 +2,9 @@ local M = {}
 
 function M.get()
 	return {
-		TelescopeBorder = { fg = C.blue },
-		TelescopeSelectionCaret = { fg = C.flamingo },
+    TelescopeNormal = { link = "NormalFloat"},
+    TelescopeBorder = { link = "FloatBorder"},
+    TelescopeSelectionCaret = { fg = C.flamingo },
 		TelescopeSelection = {
 			fg = O.transparent_background and C.flamingo or C.text,
 			bg = O.transparent_background and C.none or C.surface0,

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -4,7 +4,7 @@ function M.get()
 	return {
 		TelescopeNormal = { link = "NormalFloat" },
 		TelescopeBorder = { link = "FloatBorder" },
-    TelescopeSelectionCaret = { fg = C.flamingo },
+		TelescopeSelectionCaret = { fg = C.flamingo },
 		TelescopeSelection = {
 			fg = O.transparent_background and C.flamingo or C.text,
 			bg = O.transparent_background and C.none or C.surface0,

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -3,7 +3,7 @@ local M = {}
 function M.get()
 	return {
 		TelescopeNormal = { link = "NormalFloat" },
-    TelescopeBorder = { link = "FloatBorder"},
+		TelescopeBorder = { link = "FloatBorder" },
     TelescopeSelectionCaret = { fg = C.flamingo },
 		TelescopeSelection = {
 			fg = O.transparent_background and C.flamingo or C.text,

--- a/lua/catppuccin/groups/integrations/which_key.lua
+++ b/lua/catppuccin/groups/integrations/which_key.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.get()
 	return {
-    WhichKey = { link = "NormalFloat"},
+		WhichKey = { link = "NormalFloat" },
     WhichKeyBorder = { link = "FloatBorder"},
 
     WhichKeyGroup = { fg = C.blue },

--- a/lua/catppuccin/groups/integrations/which_key.lua
+++ b/lua/catppuccin/groups/integrations/which_key.lua
@@ -3,7 +3,7 @@ local M = {}
 function M.get()
 	return {
 		WhichKey = { link = "NormalFloat" },
-    WhichKeyBorder = { link = "FloatBorder"},
+		WhichKeyBorder = { link = "FloatBorder" },
 
     WhichKeyGroup = { fg = C.blue },
 		WhichKeySeperator = { fg = C.overlay0 },

--- a/lua/catppuccin/groups/integrations/which_key.lua
+++ b/lua/catppuccin/groups/integrations/which_key.lua
@@ -5,7 +5,7 @@ function M.get()
 		WhichKey = { link = "NormalFloat" },
 		WhichKeyBorder = { link = "FloatBorder" },
 
-    WhichKeyGroup = { fg = C.blue },
+		WhichKeyGroup = { fg = C.blue },
 		WhichKeySeperator = { fg = C.overlay0 },
 		WhichKeyDesc = { fg = C.pink },
 		WhichKeyValue = { fg = C.overlay0 },

--- a/lua/catppuccin/groups/integrations/which_key.lua
+++ b/lua/catppuccin/groups/integrations/which_key.lua
@@ -2,11 +2,12 @@ local M = {}
 
 function M.get()
 	return {
-		WhichKey = { fg = C.flamingo },
-		WhichKeyGroup = { fg = C.blue },
+    WhichKey = { link = "NormalFloat"},
+    WhichKeyBorder = { link = "FloatBorder"},
+
+    WhichKeyGroup = { fg = C.blue },
 		WhichKeySeperator = { fg = C.overlay0 },
 		WhichKeyDesc = { fg = C.pink },
-		WhichKeyBorder = { fg = C.blue },
 		WhichKeyValue = { fg = C.overlay0 },
 	}
 end


### PR DESCRIPTION
This PR links the FloatBorder and NormalFloat highlights, for which_key and telescope plugin, to catppuccin's default highlights group.

This makes it easier to change the style for all the floating windows by overwriting the catppuccin highlight groups and have the changes propagate to other plugins.

Side effect: Telescope's bg is set to base in the plugin integration and now it will be set to mantle as this is the default bg highlight for NormalFloat