### PR TITLE
fix(nvim-treesitter-context): make `TreesitterContext` more readable when using `transparent_background` option

### DIFF
--- a/lua/catppuccin/groups/integrations/treesitter_context.lua
+++ b/lua/catppuccin/groups/integrations/treesitter_context.lua
@@ -3,7 +3,6 @@ local M = {}
 function M.get()
 	return {
 		TreesitterContext = { bg = C.mantle, fg = C.text },
-		TreesitterContextLineNumber = { fg = C.surface1 },
 	}
 end
 

--- a/lua/catppuccin/groups/integrations/treesitter_context.lua
+++ b/lua/catppuccin/groups/integrations/treesitter_context.lua
@@ -2,10 +2,7 @@ local M = {}
 
 function M.get()
 	return {
-		TreesitterContext = {
-			bg = O.transparent_background and C.none or C.mantle,
-			fg = C.text,
-		},
+		TreesitterContext = { bg = C.mantle, fg = C.text },
 		TreesitterContextLineNumber = { fg = C.surface1 },
 	}
 end


### PR DESCRIPTION
This PR closes #445 