### PR TITLE
feat(colorschemes)!: persist g:colors_name in colorschemes

### DIFF
--- a/lua/catppuccin/lib/compiler.lua
+++ b/lua/catppuccin/lib/compiler.lua
@@ -29,9 +29,10 @@ return string.dump(function()
 vim.o.termguicolors = true
 if vim.g.colors_name then vim.cmd("hi clear") end
 vim.o.background = "%s"
-vim.g.colors_name = "catppuccin"
+vim.g.colors_name = "catppuccin-%s"
 local h = vim.api.nvim_set_hl]],
-			flavour == "latte" and "light" or "dark"
+			flavour == "latte" and "light" or "dark",
+			flavour
 		),
 	}
 	if path_sep == "\\" then O.compile_path = O.compile_path:gsub("/", "\\") end

--- a/lua/catppuccin/lib/vim/compiler.lua
+++ b/lua/catppuccin/lib/vim/compiler.lua
@@ -17,8 +17,9 @@ if exists("colors_name")
 endif
 set termguicolors
 set background=%s
-let g:colors_name = "catppuccin"]],
-			(flavour == "latte" and "light" or "dark")
+let g:colors_name = "catppuccin-%s"]],
+			(flavour == "latte" and "light" or "dark"),
+			flavour
 		),
 	}
 


### PR DESCRIPTION
Thanks so much for all the work on the Neovim theme!

Here's a slight improvement that sets the `g:colors_name` whenever you do `:colorscheme catppuccin-<variant>`. Some reasons why you'd want this:

- When using `:Telescope colorschemes` to select a variant, you can use Telescope again and the same variant will be selected.

- You might have a config that persists color schemes for the next Neovim startup. (this is what I do!)