### PR TITLE
fix(barbecue): apply same bg as statusline has

### DIFF
--- a/lua/barbecue/theme/catppuccin.lua
+++ b/lua/barbecue/theme/catppuccin.lua
@@ -5,8 +5,10 @@ local dirname_color = O.integrations.barbecue.dim_dirname and C.overlay1 or C.te
 local basename_bold = O.integrations.barbecue.bold_basename
 local context_color = O.integrations.barbecue.dim_context and C.overlay1 or C.text
 
+local transparent_bg = O.transparent_background and "NONE" or C.mantle
+
 local M = {
-	normal = { fg = C.text, bg = "none" },
+	normal = { fg = C.text, bg = transparent_bg },
 
 	ellipsis = { fg = C.overlay1 },
 	separator = { fg = C.overlay1 },


### PR DESCRIPTION
I suggest to set the same background color for winbar (barbecue), as statusline (lualine) has, for consistency:

<img width="912" alt="image" src="https://user-images.githubusercontent.com/26388769/233099172-14fb1881-6407-4651-8343-d9e79d6e3a93.png">

I looked at VSCode, status line has the same color as tab line has and context line is slightly brighter than both, but darker than regular text background. Maybe the color of winbar or statusline should be changed to another color or adjusted to VSCode colors.