### PR TITLE
feat(alpha): add support for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Below is a list of supported plugins and their corresponding integration module.
 
 | Plugin                                                                                | Module              |
 | ------------------------------------------------------------------------------------- | ------------------- |
+| [alpha-vim](https://github.com/goolord/alpha-nvim)                                    | alpha               |
 | [aerial.nvim](https://github.com/stevearc/aerial.nvim)                                | aerial              |
 | [barbar.nvim](https://github.com/romgrk/barbar.nvim)                                  | barbar              |
 | [barbecue.nvim](https://github.com/utilyre/barbecue.nvim)                             | barbecue, Special   |

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -351,6 +351,8 @@ module. (See Special integrations
   -------------------------------------------------------------------------------
   Plugin                                                     Module
   ---------------------------------------------------------- --------------------
+  alpha-nvim                                                 alpha
+
   aerial.nvim                                                aerial
 
   barbar.nvim                                                barbar

--- a/lua/catppuccin/groups/integrations/alpha.lua
+++ b/lua/catppuccin/groups/integrations/alpha.lua
@@ -4,9 +4,9 @@ function M.get()
 	return {
         AlphaShortcut = { fg = C.pink },
         AlphaHeader = { fg = C.blue },
-        DashboardCenter = { fg = C.green },
+        AlphaButtons = { fg = C.green },
         AlphaFooter = { fg = C.yellow, style = { "italic" } },
-	}
+    }
 end
 
 return M

--- a/lua/catppuccin/groups/integrations/alpha.lua
+++ b/lua/catppuccin/groups/integrations/alpha.lua
@@ -1,12 +1,13 @@
 local M = {}
 
 function M.get()
-    return {
-        AlphaShortcut = { fg = C.green },
-        AlphaHeader = { fg = C.blue },
-        AlphaButtons = { fg = C.pink },
-        AlphaFooter = { fg = C.yellow, style = { "italic" } },
-    }
+	return {
+		AlphaShortcut = { fg = C.green },
+		AlphaHeader = { fg = C.blue },
+		AlphaHeaderLabel = { fg = C.peach },
+		AlphaButtons = { fg = C.lavender },
+		AlphaFooter = { fg = C.yellow, style = { "italic" } },
+	}
 end
 
 return M

--- a/lua/catppuccin/groups/integrations/alpha.lua
+++ b/lua/catppuccin/groups/integrations/alpha.lua
@@ -2,9 +2,9 @@ local M = {}
 
 function M.get()
 	return {
-        AlphaShortcut = { fg = C.pink },
+        AlphaShortcut = { fg = C.green },
         AlphaHeader = { fg = C.blue },
-        AlphaButtons = { fg = C.green },
+        AlphaButtons = { fg = C.pink },
         AlphaFooter = { fg = C.yellow, style = { "italic" } },
     }
 end

--- a/lua/catppuccin/groups/integrations/alpha.lua
+++ b/lua/catppuccin/groups/integrations/alpha.lua
@@ -2,10 +2,10 @@ local M = {}
 
 function M.get()
 	return {
-        AlphaShortcut = { fg = colors.pink },
-        AlphaHeader = { fg = colors.blue },
-        DashboardCenter = { fg = colors.green },
-        AlphaFooter = { fg = colors.yellow, style = { "italic" } },
+        AlphaShortcut = { fg = C.pink },
+        AlphaHeader = { fg = C.blue },
+        DashboardCenter = { fg = C.green },
+        AlphaFooter = { fg = C.yellow, style = { "italic" } },
 	}
 end
 

--- a/lua/catppuccin/groups/integrations/alpha.lua
+++ b/lua/catppuccin/groups/integrations/alpha.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+function M.get()
+	return {
+        AlphaShortcut = { fg = colors.pink },
+        AlphaHeader = { fg = colors.blue },
+        DashboardCenter = { fg = colors.green },
+        AlphaFooter = { fg = colors.yellow, style = { "italic" } },
+	}
+end
+
+return M

--- a/lua/catppuccin/groups/integrations/alpha.lua
+++ b/lua/catppuccin/groups/integrations/alpha.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.get()
-	return {
+    return {
         AlphaShortcut = { fg = C.green },
         AlphaHeader = { fg = C.blue },
         AlphaButtons = { fg = C.pink },

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -33,6 +33,7 @@ local M = {
 			operators = {},
 		},
 		integrations = {
+			alpha = true,
 			cmp = true,
 			dashboard = true,
 			gitsigns = true,

--- a/vim.yml
+++ b/vim.yml
@@ -209,6 +209,9 @@ globals:
   O.integrations.dashboard:
     type: bool
     property: read-only
+  O.integrations.alpha:
+    type: bool
+    property: read-only
   O.integrations.gitsigns:
     type: bool
     property: read-only


### PR DESCRIPTION
Hi :wave:,

I am using [alpha-vim](https://github.com/goolord/alpha-nvim)  extension. Specifically the way [LazyVim](https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/plugins/ui.lua#L267-L275) has configured it

 I wanted to add the catppuccin theme to it, else it was all white.

This is what it looks like: 

![image](https://user-images.githubusercontent.com/998807/235263323-b1e91cf8-6028-473b-964b-52669862771d.png)

Open to feedback thanks!