### PR TITLE
feat(treesitter): enable @keyword.export for js

### DIFF
--- a/after/queries/javascript/highlights.scm
+++ b/after/queries/javascript/highlights.scm
@@ -1,0 +1,4 @@
+;; extends
+[
+"export"
+] @keyword.export


### PR DESCRIPTION
Enable highlight override for `["@keyword.export"]` in `js` and `mjs` files

Fix for #466 