### PR TITLE
add group for dashboard hyper theme

### DIFF
--- a/lua/catppuccin/groups/integrations/dashboard.lua
+++ b/lua/catppuccin/groups/integrations/dashboard.lua
@@ -6,6 +6,9 @@ function M.get()
 		DashboardHeader = { fg = C.blue },
 		DashboardCenter = { fg = C.green },
 		DashboardFooter = { fg = C.yellow, style = { "italic" } },
+		DashboardMruTitle = { fg = C.sky },
+		DashboardProjectTitle = { fg = C.sky },
+		DashboardFiles = { fg = C.lavender },
 	}
 end
 


### PR DESCRIPTION
Hi, dashboard-nvim now have a new theme called hyper https://github.com/catppuccin/nvim/compare/main...fecet:nvim:feat/dashboard-hyper?expand=1, 
With reference to the original themes of Alpha and Dashboard, I have created this one.
![image](https://user-images.githubusercontent.com/41792945/235338967-fc74aaef-4e24-475c-b15f-a3f36de80c5e.png)

Any input is highly appreciated.