### PR TITLE
fix(neotree): set correct color for inactive neotree window

### DIFF
--- a/lua/catppuccin/groups/integrations/neotree.lua
+++ b/lua/catppuccin/groups/integrations/neotree.lua
@@ -7,6 +7,7 @@ function M.get()
 		NeoTreeDirectoryName = { fg = C.blue },
 		NeoTreeDirectoryIcon = { fg = C.blue },
 		NeoTreeNormal = { fg = C.text, bg = active_bg },
+		NeoTreeNormalNc = { fg = C.text, bg = active_bg },
 		NeoTreeExpander = { fg = C.overlay0 },
 		NeoTreeIndentMarker = { fg = C.overlay0 },
 		NeoTreeRootName = { fg = C.blue, style = { "bold" } },


### PR DESCRIPTION
NeoTree links its `NeoTreeNormalNc` highlight group to `NormalNc`. This means that when the NeoTree window becomes inactive, it reuses the same color that is set for `NormalNc`. This causes issues, as this will cause the window to switch to the same color as the other windows, if dim is not enabled.

To fix this, the `NeoTreeNormalNc` color is now explicitly set to the same value as `NeoTreeNormal`.

fixes #476