### PR TITLE
fix: make `CursorLine` visible for `transparent_background`

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -9,8 +9,7 @@ function M.get()
 		CursorIM = { fg = C.base, bg = C.text }, -- like Cursor, but used when in IME mode |CursorIM|
 		CursorColumn = { bg = C.mantle }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
 		CursorLine = {
-			bg = O.transparent_background and C.none
-				or U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),
+			bg = U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),
 		}, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if forecrust (ctermfg OR guifg) is not set.
 		Directory = { fg = C.blue }, -- directory names (and other special names in listings)
 		EndOfBuffer = { fg = O.show_end_of_buffer and C.surface1 or C.base }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.


### PR DESCRIPTION
Resolves a conflict between `catppuccin`'s transparent mode and `neo-tree` where `neo-tree`'s fuzzy search would have an invisible `CursorLine`, making it hard to know which item is being selected.

## Before

![image](https://github.com/catppuccin/nvim/assets/38332081/b42df5b4-83f3-46ef-872c-6a5d49de89a3)

## After

![image](https://github.com/catppuccin/nvim/assets/38332081/8b23ebfd-0aaf-4848-837d-21e58f642235)
