### PR TITLE
feat(markdown): add rainbow headlines

### DIFF
--- a/lua/catppuccin/groups/integrations/headlines.lua
+++ b/lua/catppuccin/groups/integrations/headlines.lua
@@ -6,11 +6,11 @@ function M.get()
 		Quote = { link = "@text.strong" },
 		CodeBlock = { bg = C.mantle },
 		Headline = { link = "Headline1" },
-		Headline1 = { bg = C.surface0, fg = C.green },
-		Headline2 = { bg = C.surface0, fg = C.blue },
-		Headline3 = { bg = C.surface0, fg = C.red },
-		Headline4 = { bg = C.surface0, fg = C.mauve },
-		Headline5 = { bg = C.surface0, fg = C.yellow },
+		Headline1 = { bg = C.surface0, fg = C.red },
+		Headline2 = { bg = C.surface0, fg = C.peach },
+		Headline3 = { bg = C.surface0, fg = C.yellow },
+		Headline4 = { bg = C.surface0, fg = C.green },
+		Headline5 = { bg = C.surface0, fg = C.sapphire },
 		Headline6 = { bg = C.surface0, fg = C.lavender },
 	}
 end

--- a/lua/catppuccin/groups/integrations/markdown.lua
+++ b/lua/catppuccin/groups/integrations/markdown.lua
@@ -6,12 +6,12 @@ function M.get()
 		markdownCode = { fg = C.flamingo },
 		markdownCodeBlock = { fg = C.flamingo },
 		markdownLinkText = { fg = C.blue, style = { "underline" } },
-		markdownH1 = { fg = C.lavender },
-		markdownH2 = { fg = C.mauve },
-		markdownH3 = { fg = C.green },
-		markdownH4 = { fg = C.yellow },
-		markdownH5 = { fg = C.pink },
-		markdownH6 = { fg = C.teal },
+		markdownH1 = { link = "rainbow1" },
+		markdownH2 = { link = "rainbow2" },
+		markdownH3 = { link = "rainbow3" },
+		markdownH4 = { link = "rainbow4" },
+		markdownH5 = { link = "rainbow5" },
+		markdownH6 = { link = "rainbow6" },
 	}
 end
 

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -122,6 +122,14 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Language specific:
 
+		-- markdown
+		["@text.title.2.markdown"] = { link = "rainbow2" },
+		["@text.title.1.markdown"] = { link = "rainbow1" },
+		["@text.title.3.markdown"] = { link = "rainbow3" },
+		["@text.title.4.markdown"] = { link = "rainbow4" },
+		["@text.title.5.markdown"] = { link = "rainbow5" },
+		["@text.title.6.markdown"] = { link = "rainbow6" },
+
 		-- css
 		["@property.css"] = { fg = C.lavender },
 		["@property.id.css"] = { fg = C.blue },

--- a/lua/catppuccin/groups/syntax.lua
+++ b/lua/catppuccin/groups/syntax.lua
@@ -88,6 +88,14 @@ function M.get()
 		GlyphPalette6 = { fg = C.teal },
 		GlyphPalette7 = { fg = C.text },
 		GlyphPalette9 = { fg = C.red },
+
+		-- rainbow
+		rainbow1 = { fg = C.red },
+		rainbow2 = { fg = C.peach },
+		rainbow3 = { fg = C.yellow },
+		rainbow4 = { fg = C.green },
+		rainbow5 = { fg = C.sapphire },
+		rainbow6 = { fg = C.lavender },
 	}
 end
 


### PR DESCRIPTION
Close #492 

Colors taken from [catppuccin style guide rainbow highlights](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md#--------------rainbow-highlights--------------brackets-headings-etc------------)

![image](https://github.com/catppuccin/nvim/assets/56817415/b5b2ab3a-5577-44b6-8d84-d7377d1ed546)