### PR TITLE
fix typo wrt fidget.nvim setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,7 +592,7 @@ fern = false
 <td>
 
 ```lua
-fern = false
+fidget = false
 ```
 
 <details> <summary>Special</summary>


### PR DESCRIPTION
fixes typo wrt fidget.nvim setting — it looks like a copy-paste-o from the row above.