### PR TITLE
docs: fix lazy.nvim install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This port of <a href="https://github.com/catppuccin/">Catppuccin</a> is special 
 
 [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
-{ "catppuccin/nvim", name = "catppuccin" }
+{ "catppuccin/nvim", name = "catppuccin", lazy = false, priority = 100 }
 ```
 
 [packer.nvim](https://github.com/wbthomason/packer.nvim)


### PR DESCRIPTION
as per the docs, colorschemes should be eager-loaded loaded with higher than default priority

> Only useful for start plugins (lazy=false) to force loading certain plugins first. Default priority is 50. It's recommended to set this to a high number for colorschemes.
- https://github.com/folke/lazy.nvim#-plugin-spec