### PR TITLE
fix(lsp): do not link `LspInlayHint` to `Comment` directly

### DIFF
--- a/lua/catppuccin/groups/integrations/native_lsp.lua
+++ b/lua/catppuccin/groups/integrations/native_lsp.lua
@@ -87,8 +87,9 @@ function M.get()
 		LspInlayHint = {
 			-- fg of `Comment`
 			fg = C.overlay0,
-			-- bg of `CursorLine`
-			bg = U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),
+			bg = O.transparent_background and C.none
+				-- bg of `CursorLine`
+				or U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),
 		}, -- virtual text of the inlay hints
 		LspInfoBorder = { link = "FloatBorder" }, -- LspInfo border
 	}

--- a/lua/catppuccin/groups/integrations/native_lsp.lua
+++ b/lua/catppuccin/groups/integrations/native_lsp.lua
@@ -84,7 +84,12 @@ function M.get()
 		LspDiagnosticsUnderlineInformation = { style = underlines.information, sp = info }, -- Used to underline "Information" diagnostics
 		LspDiagnosticsUnderlineHint = { style = underlines.hints, sp = hint }, -- Used to underline "Hint" diagnostics
 		LspCodeLens = { fg = C.overlay0 }, -- virtual text of the codelens
-		LspInlayHint = { link = "Comment" }, -- virtual text of the inlay hints
+		LspInlayHint = {
+			-- fg of `Comment`
+			fg = C.overlay0,
+			-- bg of `CursorLine`
+			bg = U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),
+		}, -- virtual text of the inlay hints
 		LspInfoBorder = { link = "FloatBorder" }, -- LspInfo border
 	}
 end

--- a/lua/catppuccin/groups/integrations/native_lsp.lua
+++ b/lua/catppuccin/groups/integrations/native_lsp.lua
@@ -87,8 +87,8 @@ function M.get()
 		LspInlayHint = {
 			-- fg of `Comment`
 			fg = C.overlay0,
+			-- bg of `CursorLine`
 			bg = O.transparent_background and C.none
-				-- bg of `CursorLine`
 				or U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),
 		}, -- virtual text of the inlay hints
 		LspInfoBorder = { link = "FloatBorder" }, -- LspInfo border


### PR DESCRIPTION
The former commit links `Comment` to `LspInalyHint`,
I think the foreground color is very proper to use,
but there is a problem,
catppuccin allows users to customize styles of comments and keywords, 
if the style of comment was set to italic, which is very commonly used,
style of `LspInlayHint` would be italic too.

In addition, in order to make the background color of `LspInlayHint` lighter than
the basic background color for distinction (vscode also does this),
I recommend using the background color of `CursorLine`.