### PR TITLE
fix(treesitter_context): underline content if `transparent_background` is true

### DIFF
--- a/lua/catppuccin/groups/integrations/treesitter_context.lua
+++ b/lua/catppuccin/groups/integrations/treesitter_context.lua
@@ -1,8 +1,10 @@
 local M = {}
 
 function M.get()
+	local transparent_background = require("catppuccin").options.transparent_background
+	local bg_highlight = transparent_background and "NONE" or C.mantle
 	return {
-		TreesitterContext = { bg = C.mantle, fg = C.text },
+		TreesitterContext = { bg = bg_highlight, fg = C.text },
 	}
 end
 

--- a/lua/catppuccin/groups/integrations/treesitter_context.lua
+++ b/lua/catppuccin/groups/integrations/treesitter_context.lua
@@ -1,12 +1,7 @@
 local M = {}
 
 function M.get()
-	local transparent_background = require("catppuccin").options.transparent_background
-	local bg_highlight = transparent_background and "NONE" or C.mantle
-	return {
-		TreesitterContext = { bg = bg_highlight, fg = C.text },
-		TreesitterContextBottom = { gui = "underline", guisp = C.dim },
-	}
+	return O.transparent_background and { TreesitterContextBottom = { sp = C.dim, style = { "underline" } } } or {}
 end
 
 return M

--- a/lua/catppuccin/groups/integrations/treesitter_context.lua
+++ b/lua/catppuccin/groups/integrations/treesitter_context.lua
@@ -5,6 +5,7 @@ function M.get()
 	local bg_highlight = transparent_background and "NONE" or C.mantle
 	return {
 		TreesitterContext = { bg = bg_highlight, fg = C.text },
+		TreesitterContextBottom = { gui = "underline", guisp = C.dim },
 	}
 end
 


### PR DESCRIPTION
Updates the Treesitter Context plugin to use a transparent background if transparent_background was set.