### PR TITLE
feat(telescope): flat style

### DIFF
--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -1,27 +1,70 @@
 local M = {}
 
 function M.get()
-	return {
-		-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
-		TelescopeBorder = { link = "FloatBorder" },
-		TelescopeSelectionCaret = { fg = C.flamingo },
-		TelescopeSelection = {
-			fg = O.transparent_background and C.flamingo or C.text,
-			bg = O.transparent_background and C.none or C.surface0,
-			style = { "bold" },
-		},
-		TelescopeMatching = { fg = C.blue },
-		-- TelescopePromptPrefix = { bg = C.crust },
-		-- TelescopePromptNormal = { bg = C.crust },
-		-- TelescopeResultsNormal = { bg = C.mantle },
-		-- TelescopePreviewNormal = { bg = C.crust },
-		-- TelescopePromptBorder = { bg = C.crust, fg = C.crust },
-		-- TelescopeResultsBorder = { bg = C.mantle, fg = C.crust },
-		-- TelescopePreviewBorder = { bg = C.crust, fg = C.crust },
-		-- TelescopePromptTitle = { fg = C.crust },
-		-- TelescopeResultsTitle = { fg = C.text },
-		-- TelescopePreviewTitle = { fg = C.crust },
-	}
+	if O.integrations.telescope.style == 'classic' then
+		-- Classic look
+		return {
+			-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
+			TelescopeBorder = { link = "FloatBorder" },
+			TelescopeSelectionCaret = { fg = C.flamingo },
+			TelescopeSelection = {
+				fg = O.transparent_background and C.flamingo or C.text,
+				bg = O.transparent_background and C.none or C.surface0,
+				style = { "bold" },
+			},
+			TelescopeMatching = { fg = C.blue },
+		}
+	end
+
+	if O.integrations.telescope.style == 'flat' then
+		-- Flat look
+		return {
+			TelescopePromptPrefix = {
+				bg = C.crust
+			},
+			TelescopeSelectionCaret = {
+				fg = C.rosewater,
+				bg = C.surface1,
+				bold = true
+			},
+			TelescopePromptNormal = {
+				bg = C.crust
+			},
+			TelescopeResultsNormal = {
+				bg = C.mantle
+			},
+			TelescopePreviewNormal = {
+				bg = C.mantle
+			},
+			TelescopePromptBorder = {
+				bg = C.crust,
+				fg = C.crust
+			},
+			TelescopeResultsBorder = {
+				bg = C.mantle,
+				fg = C.mantle
+			},
+			TelescopePreviewBorder = {
+				bg = C.mantle,
+				fg = C.mantle
+			},
+			TelescopePromptTitle = {
+				bg = C.rosewater,
+				fg = C.base,
+				bold = true
+			},
+			TelescopeResultsTitle = {
+				bg = C.rosewater,
+				fg = C.base,
+				bold = true
+			},
+			TelescopePreviewTitle = {
+				bg = C.lavender,
+				fg = C.base,
+				bold = true
+			},
+		}
+	end
 end
 
 return M

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -42,7 +42,10 @@ local M = {
 			markdown = true,
 			nvimtree = true,
 			semantic_tokens = not is_vim,
-			telescope = true,
+			telescope = {
+				enabled = true,
+				style = "flat",
+			},
 			treesitter = not is_vim,
 			ts_rainbow = true,
 			ts_rainbow2 = true,

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -58,7 +58,7 @@
 ---@field navic CtpIntegrationNavic
 ---@field nvimtree boolean
 ---@field semantic_tokens boolean
----@field telescope boolean
+---@field telescope CtpIntegrationTelescope
 ---@field treesitter boolean
 ---@field ts_rainbow boolean
 ---@field ts_rainbow2 boolean
@@ -85,6 +85,10 @@
 ---@class CtpIntegrationNavic
 ---@field enabled boolean? Whether to enable the navic integration.
 ---@field custom_bg string? Override the background color for navic.
+
+---@class CtpIntegrationTelescope
+---@field enabled boolean? Whether to enable the telescope integration
+---@field style string? The style of Telescope "classic" | "flat"
 
 ---@alias CtpHighlightArgs "bold" | "underline" | "undercurl" | "underdouble" | "underdotted" | "underdashed" | "strikethrough" | "reverse" | "inverse" | "italic" | "standout" | "altfont" | "nocombine" | "NONE"
 ---@alias CtpHighlightOverrideFn fun(colors: CtpColors<string>): { [string]: CtpHighlight}


### PR DESCRIPTION
Allow the user to choose Telescope style between `"flat"` and `"classic"`

- Classic look (the original Catppuccin Telescope integration):

<img width="1258" alt="Screenshot 2023-06-24 at 11 31 36" src="https://github.com/catppuccin/nvim/assets/71718049/f9ae5b2d-2c55-4eae-91d3-2b87724f9870">

- Flat look:

<img width="1258" alt="Screenshot 2023-06-24 at 11 32 11" src="https://github.com/catppuccin/nvim/assets/71718049/323a5dd9-25cd-4e31-8746-c7c62b94ce64">
