### PR TITLE
feat(telescope): telescope flat style support

### DIFF
--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -706,7 +706,7 @@ telekasten.nvim>lua
 telescope.nvim>lua
     telescope = {
 	enabled = true,
-	style = "classic" | "flat",
+	style = "classic" | "nvchad",
     }
 <
 

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -704,7 +704,10 @@ telekasten.nvim>lua
 <
 
 telescope.nvim>lua
-    telescope = true
+    telescope = {
+	enabled = true,
+	style = "classic" | "flat",
+    }
 <
 
 trouble.nvim>lua

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -16,7 +16,7 @@ function M.get()
 		}
 	end
 
-	if O.integrations.telescope.style == 'classic' then
+	if O.integrations.telescope.style == "classic" then
 		-- Classic look
 		return {
 			-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
@@ -29,55 +29,20 @@ function M.get()
 			},
 			TelescopeMatching = { fg = C.blue },
 		}
-	end
-
-	if O.integrations.telescope.style == 'nvchad' then
+	elseif O.integrations.telescope.style == "nvchad" then
 		-- Flat look
 		return {
-			TelescopePromptPrefix = {
-				bg = C.crust
-			},
-			TelescopeSelectionCaret = {
-				fg = C.rosewater,
-				bg = C.surface1,
-				bold = true
-			},
-			TelescopePromptNormal = {
-				bg = C.crust
-			},
-			TelescopeResultsNormal = {
-				bg = C.mantle
-			},
-			TelescopePreviewNormal = {
-				bg = C.mantle
-			},
-			TelescopePromptBorder = {
-				bg = C.crust,
-				fg = C.crust
-			},
-			TelescopeResultsBorder = {
-				bg = C.mantle,
-				fg = C.mantle
-			},
-			TelescopePreviewBorder = {
-				bg = C.mantle,
-				fg = C.mantle
-			},
-			TelescopePromptTitle = {
-				bg = C.rosewater,
-				fg = C.base,
-				bold = true
-			},
-			TelescopeResultsTitle = {
-				bg = C.rosewater,
-				fg = C.base,
-				bold = true
-			},
-			TelescopePreviewTitle = {
-				bg = C.lavender,
-				fg = C.base,
-				bold = true
-			},
+			TelescopePromptPrefix = { bg = C.crust },
+			TelescopeSelectionCaret = { fg = C.rosewater, bg = C.surface1, bold = true },
+			TelescopePromptNormal = { bg = C.crust },
+			TelescopeResultsNormal = { bg = C.mantle },
+			TelescopePreviewNormal = { bg = C.mantle },
+			TelescopePromptBorder = { bg = C.crust, fg = C.crust },
+			TelescopeResultsBorder = { bg = C.mantle, fg = C.mantle },
+			TelescopePreviewBorder = { bg = C.mantle, fg = C.mantle },
+			TelescopePromptTitle = { bg = C.rosewater, fg = C.base, bold = true },
+			TelescopeResultsTitle = { bg = C.rosewater, fg = C.base, bold = true },
+			TelescopePreviewTitle = { bg = C.lavender, fg = C.base, bold = true },
 		}
 	end
 end

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -1,5 +1,20 @@
 local M = {}
 
+-- Backwards compatibility
+if type(O.integrations.telescope) == "boolean" then
+	O.integrations.telescope = {
+		-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
+		TelescopeBorder = { link = "FloatBorder" },
+		TelescopeSelectionCaret = { fg = C.flamingo },
+		TelescopeSelection = {
+			fg = O.transparent_background and C.flamingo or C.text,
+			bg = O.transparent_background and C.none or C.surface0,
+			style = { "bold" },
+		},
+		TelescopeMatching = { fg = C.blue },
+	}
+end
+
 function M.get()
 	if O.integrations.telescope.style == 'classic' then
 		-- Classic look
@@ -16,7 +31,7 @@ function M.get()
 		}
 	end
 
-	if O.integrations.telescope.style == 'flat' then
+	if O.integrations.telescope.style == 'nvchad' then
 		-- Flat look
 		return {
 			TelescopePromptPrefix = {

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -1,21 +1,21 @@
 local M = {}
 
--- Backwards compatibility
-if type(O.integrations.telescope) == "boolean" then
-	O.integrations.telescope = {
-		-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
-		TelescopeBorder = { link = "FloatBorder" },
-		TelescopeSelectionCaret = { fg = C.flamingo },
-		TelescopeSelection = {
-			fg = O.transparent_background and C.flamingo or C.text,
-			bg = O.transparent_background and C.none or C.surface0,
-			style = { "bold" },
-		},
-		TelescopeMatching = { fg = C.blue },
-	}
-end
-
 function M.get()
+	-- Backwards compatibility
+	if type(O.integrations.telescope) == "boolean" then
+		return {
+			-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
+			TelescopeBorder = { link = "FloatBorder" },
+			TelescopeSelectionCaret = { fg = C.flamingo },
+			TelescopeSelection = {
+				fg = O.transparent_background and C.flamingo or C.text,
+				bg = O.transparent_background and C.none or C.surface0,
+				style = { "bold" },
+			},
+			TelescopeMatching = { fg = C.blue },
+		}
+	end
+
 	if O.integrations.telescope.style == 'classic' then
 		-- Classic look
 		return {

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -1,27 +1,70 @@
 local M = {}
 
 function M.get()
-	return {
-		-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
-		TelescopeBorder = { link = "FloatBorder" },
-		TelescopeSelectionCaret = { fg = C.flamingo },
-		TelescopeSelection = {
-			fg = O.transparent_background and C.flamingo or C.text,
-			bg = O.transparent_background and C.none or C.surface0,
-			style = { "bold" },
-		},
-		TelescopeMatching = { fg = C.blue },
-		-- TelescopePromptPrefix = { bg = C.crust },
-		-- TelescopePromptNormal = { bg = C.crust },
-		-- TelescopeResultsNormal = { bg = C.mantle },
-		-- TelescopePreviewNormal = { bg = C.crust },
-		-- TelescopePromptBorder = { bg = C.crust, fg = C.crust },
-		-- TelescopeResultsBorder = { bg = C.mantle, fg = C.crust },
-		-- TelescopePreviewBorder = { bg = C.crust, fg = C.crust },
-		-- TelescopePromptTitle = { fg = C.crust },
-		-- TelescopeResultsTitle = { fg = C.text },
-		-- TelescopePreviewTitle = { fg = C.crust },
-	}
+	if O.integrations.telescope.style == 'classic' then
+		-- Classic look
+		return {
+			-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
+			TelescopeBorder = { link = "FloatBorder" },
+			TelescopeSelectionCaret = { fg = C.flamingo },
+			TelescopeSelection = {
+				fg = O.transparent_background and C.flamingo or C.text,
+				bg = O.transparent_background and C.none or C.surface0,
+				style = { "bold" },
+			},
+			TelescopeMatching = { fg = C.blue },
+		}
+	end
+
+	if O.integrations.telescope.style == 'flat' then
+		-- Flat look
+		return {
+			TelescopePromptPrefix = {
+				bg = C.crust
+			},
+			TelescopeSelectionCaret = {
+				fg = C.rosewater,
+				bg = C.surface1,
+				bold = true
+			},
+			TelescopePromptNormal = {
+				bg = C.crust
+			},
+			TelescopeResultsNormal = {
+				bg = C.mantle
+			},
+			TelescopePreviewNormal = {
+				bg = C.mantle
+			},
+			TelescopePromptBorder = {
+				bg = C.crust,
+				fg = C.crust
+			},
+			TelescopeResultsBorder = {
+				bg = C.mantle,
+				fg = C.mantle
+			},
+			TelescopePreviewBorder = {
+				bg = C.mantle,
+				fg = C.mantle
+			},
+			TelescopePromptTitle = {
+				bg = C.rosewater,
+				fg = C.base,
+				bold = true
+			},
+			TelescopeResultsTitle = {
+				bg = C.rosewater,
+				fg = C.base,
+				bold = true
+			},
+			TelescopePreviewTitle = {
+				bg = C.lavender,
+				fg = C.base,
+				bold = true
+			},
+		}
+	end
 end
 
 return M

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -42,7 +42,10 @@ local M = {
 			markdown = true,
 			nvimtree = true,
 			semantic_tokens = not is_vim,
-			telescope = true,
+			telescope = {
+				enabled = true,
+				style = "flat",
+			},
 			treesitter = not is_vim,
 			ts_rainbow = true,
 			ts_rainbow2 = true,

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -44,7 +44,7 @@ local M = {
 			semantic_tokens = not is_vim,
 			telescope = {
 				enabled = true,
-				style = "flat",
+				style = "classic",
 			},
 			treesitter = not is_vim,
 			ts_rainbow = true,

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -58,7 +58,7 @@
 ---@field navic CtpIntegrationNavic
 ---@field nvimtree boolean
 ---@field semantic_tokens boolean
----@field telescope boolean
+---@field telescope CtpIntegrationTelescope
 ---@field treesitter boolean
 ---@field ts_rainbow boolean
 ---@field ts_rainbow2 boolean
@@ -85,6 +85,10 @@
 ---@class CtpIntegrationNavic
 ---@field enabled boolean? Whether to enable the navic integration.
 ---@field custom_bg string? Override the background color for navic.
+
+---@class CtpIntegrationTelescope
+---@field enabled boolean? Whether to enable the telescope integration
+---@field style string? The style of Telescope "classic" | "flat"
 
 ---@alias CtpHighlightArgs "bold" | "underline" | "undercurl" | "underdouble" | "underdotted" | "underdashed" | "strikethrough" | "reverse" | "inverse" | "italic" | "standout" | "altfont" | "nocombine" | "NONE"
 ---@alias CtpHighlightOverrideFn fun(colors: CtpColors<string>): { [string]: CtpHighlight}

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -88,7 +88,7 @@
 
 ---@class CtpIntegrationTelescope
 ---@field enabled boolean? Whether to enable the telescope integration
----@field style string? The style of Telescope "classic" | "flat"
+---@field style string? The style of Telescope "classic" | "nvchad"
 
 ---@alias CtpHighlightArgs "bold" | "underline" | "undercurl" | "underdouble" | "underdotted" | "underdashed" | "strikethrough" | "reverse" | "inverse" | "italic" | "standout" | "altfont" | "nocombine" | "NONE"
 ---@alias CtpHighlightOverrideFn fun(colors: CtpColors<string>): { [string]: CtpHighlight}

--- a/vim.yml
+++ b/vim.yml
@@ -227,9 +227,14 @@ globals:
   O.integrations.semantic_tokens:
     type: bool
     property: read-only
-  O.integrations.telescope:
+
+  O.integrations.telescope.enabled:
     type: bool
     property: read-only
+  O.integrations.telescope.style:
+    type: string
+    property: read-only
+
   O.integrations.treesitter:
     type: bool
     property: read-only


### PR DESCRIPTION
Updates the Telescope integration to allow users to choose a telescope style between "nvchad" and "classic". 
The default style currently is set to "classic"

- Classic (the original style):


<img width="1440" alt="Screenshot 2023-06-24 at 11 46 38" src="https://github.com/catppuccin/nvim/assets/71718049/557ff89e-963a-470f-ad4a-d6f81d389833">

- Nvchad (flat style)

<img width="1440" alt="Screenshot 2023-06-24 at 11 47 07" src="https://github.com/catppuccin/nvim/assets/71718049/ebd106da-c8fa-4d2d-ae18-43e8040bd31b">

