### PR TITLE
fix(native_lsp): boolean logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ coc_nvim = true,
 
 In the inners tables you can set the style for the diagnostics, both `virtual_text` (what you see on the side) and `underlines` (what points directly at the thing (e.g. an error)).
 
-```
+```lua
 native_lsp = {
     enabled = true,
     virtual_text = {
@@ -423,6 +423,9 @@ native_lsp = {
         hints = { "underline" },
         warnings = { "underline" },
         information = { "underline" },
+    },
+    inlay_hints = {
+        background = true,
     },
 },
 ```
@@ -930,6 +933,9 @@ native_lsp = {
         hints = { "underline" },
         warnings = { "underline" },
         information = { "underline" },
+    },
+    inlay_hints = {
+        background = true,
     },
 },
 ```

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -339,7 +339,7 @@ In the inners tables you can set the style for the diagnostics, both
 `virtual_text` (what you see on the side) and `underlines` (what points
 directly at the thing (e.g. an error)).
 
->
+>lua
     native_lsp = {
         enabled = true,
         virtual_text = {
@@ -353,6 +353,9 @@ directly at the thing (e.g. an error)).
             hints = { "underline" },
             warnings = { "underline" },
             information = { "underline" },
+        },
+        inlay_hints = {
+            background = true,
         },
     },
 <
@@ -629,6 +632,9 @@ nvim-lspconfig>lua
             hints = { "underline" },
             warnings = { "underline" },
             information = { "underline" },
+        },
+        inlay_hints = {
+            background = true,
         },
     },
 <

--- a/lua/catppuccin/groups/integrations/native_lsp.lua
+++ b/lua/catppuccin/groups/integrations/native_lsp.lua
@@ -89,8 +89,7 @@ function M.get()
 			-- fg of `Comment`
 			fg = C.overlay0,
 			-- bg of `CursorLine`
-			bg = (O.transparent_background
-				or not inlay_hints.background) and C.none
+			bg = (O.transparent_background or not inlay_hints.background) and C.none
 				or U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),
 		}, -- virtual text of the inlay hints
 		LspInfoBorder = { link = "FloatBorder" }, -- LspInfo border

--- a/lua/catppuccin/groups/integrations/native_lsp.lua
+++ b/lua/catppuccin/groups/integrations/native_lsp.lua
@@ -3,6 +3,7 @@ local M = {}
 function M.get()
 	local virtual_text = O.integrations.native_lsp.virtual_text
 	local underlines = O.integrations.native_lsp.underlines
+	local inlay_hints = O.integrations.native_lsp.inlay_hints
 
 	local error = C.red
 	local warning = C.yellow
@@ -88,7 +89,8 @@ function M.get()
 			-- fg of `Comment`
 			fg = C.overlay0,
 			-- bg of `CursorLine`
-			bg = O.transparent_background and C.none
+			bg = O.transparent_background
+				or not inlay_hints.background and C.none
 				or U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),
 		}, -- virtual text of the inlay hints
 		LspInfoBorder = { link = "FloatBorder" }, -- LspInfo border

--- a/lua/catppuccin/groups/integrations/native_lsp.lua
+++ b/lua/catppuccin/groups/integrations/native_lsp.lua
@@ -89,8 +89,8 @@ function M.get()
 			-- fg of `Comment`
 			fg = C.overlay0,
 			-- bg of `CursorLine`
-			bg = O.transparent_background
-				or not inlay_hints.background and C.none
+			bg = (O.transparent_background
+				or not inlay_hints.background) and C.none
 				or U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),
 		}, -- virtual text of the inlay hints
 		LspInfoBorder = { link = "FloatBorder" }, -- LspInfo border

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -73,6 +73,9 @@ local M = {
 					warnings = { "underline" },
 					information = { "underline" },
 				},
+				inlay_hints = {
+					background = true,
+				},
 			},
 			navic = {
 				enabled = false,

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -45,6 +45,9 @@
 ---@field warnings CtpHighlightArgs[] Change the style of LSP warnings.
 ---@field information CtpHighlightArgs[] Change the style of LSP information.
 
+---@class CtpNativeLspInlayHints
+---@field background boolean Toggle the background of inlay hints.
+
 ---@class CtpIntegrations
 ---@field alpha boolean
 ---@field barbecue CtpIntegrationBarbecue
@@ -81,6 +84,7 @@
 ---@field enabled boolean? Whether to enable the Native LSP integration.
 ---@field virtual_text CtpNativeLspStyles? Styles to apply to virtual text.
 ---@field underlines CtpNativeLspStyles? Styles to apply to underlines.
+---@field inlay_hints CtpNativeLspInlayHints? Inlay hints options.
 
 ---@class CtpIntegrationNavic
 ---@field enabled boolean? Whether to enable the navic integration.

--- a/vim.yml
+++ b/vim.yml
@@ -292,6 +292,10 @@ globals:
     type: string
     property: read-only
 
+  O.integrations.native_lsp.inlay_hints.background:
+    type: bool
+    property: read-only
+
   O.integrations.navic:
     type: table
     property: full-write


### PR DESCRIPTION
Fixes #523 
The error seems to be due to boolean logic in `native_lsp.lua`:
```diff
-			bg = O.transparent_background and C.none
+			bg = O.transparent_background
+				or not inlay_hints.background and C.none
```

Since `and` has priority over `or`, Lua computes `not inlay_hints.background and C.none` first, and then `O.transparent_background` or'd with the result of `and`. 
Then, if `O.transparent_background` is true (which is the case for me), the `bg` field is set to true, which causes the "invalid 'bg'" error.

Surrounding the `or` statement with parens seemed to solve the issue for me.