### PR TITLE
fix(mapper): remove unnecessary globals

### DIFF
--- a/lua/catppuccin/lib/mapper.lua
+++ b/lua/catppuccin/lib/mapper.lua
@@ -26,47 +26,46 @@ end
 
 function M.apply(flavour)
 	flavour = flavour or require("catppuccin").flavour
-	-- Borrowing global var
-	_G._O = O
-	_G._C = C
-	_G._U = U
 
-	_G.O = require("catppuccin").options
-	_G.C = require("catppuccin.palettes").get_palette(flavour)
-	_G.U = require "catppuccin.utils.colors"
+	local env = {
+		O = require("catppuccin").options,
+		C = require("catppuccin.palattes").get_palette(flavour),
+		U = require "catppuccin.utils.colors",
+	}
 
-	C.none = "NONE"
+	setmetatable(env, { __index = _G })
 
-	local dim_percentage = O.dim_inactive.percentage
-	C.dim = O.dim_inactive.shade == "dark"
+	local function theme_with_env()
+		C.none = "NONE"
+
+		local dim_percentage = O.dim_inactive.percentage
+		C.dim = O.dim_inactive.shade == "dark"
 			and U.vary_color(
 				{ latte = U.darken(C.base, dim_percentage, C.mantle) },
 				U.darken(C.base, dim_percentage, C.mantle)
 			)
-		or U.vary_color(
-			{ latte = U.lighten("#FBFCFD", dim_percentage, C.base) },
-			U.lighten(C.surface0, dim_percentage, C.base)
+			or U.vary_color(
+				{ latte = U.lighten("#FBFCFD", dim_percentage, C.base) },
+				U.lighten(C.surface0, dim_percentage, C.base)
+			)
+
+		local theme = {}
+		theme.syntax = require("catppuccin.groups.syntax").get()
+		theme.editor = require("catppuccin.groups.editor").get()
+		theme.integrations = get_integrations()                -- plugins
+		theme.terminal = require("catppuccin.groups.terminal").get() -- terminal colors
+		local user_highlights = require("catppuccin").options.highlight_overrides
+		if type(user_highlights[flavour]) == "function" then user_highlights[flavour] = user_highlights[flavour](C) end
+		theme.custom_highlights = vim.tbl_deep_extend(
+			"keep",
+			user_highlights[flavour] or {},
+			type(user_highlights.all) == "function" and user_highlights.all(C) or user_highlights.all or {}
 		)
 
-	local theme = {}
-	theme.syntax = require("catppuccin.groups.syntax").get()
-	theme.editor = require("catppuccin.groups.editor").get()
-	theme.integrations = get_integrations() -- plugins
-	theme.terminal = require("catppuccin.groups.terminal").get() -- terminal colors
-	local user_highlights = require("catppuccin").options.highlight_overrides
-	if type(user_highlights[flavour]) == "function" then user_highlights[flavour] = user_highlights[flavour](C) end
-	theme.custom_highlights = vim.tbl_deep_extend(
-		"keep",
-		user_highlights[flavour] or {},
-		type(user_highlights.all) == "function" and user_highlights.all(C) or user_highlights.all or {}
-	)
+		return theme
+	end
 
-	-- Returning global var
-	_G.O = _G._O
-	_G.C = _G._C
-	_G.U = _G._U
-
-	return theme
+	return setfenv(theme_with_env, env)()
 end
 
 return M

--- a/lua/catppuccin/lib/mapper.lua
+++ b/lua/catppuccin/lib/mapper.lua
@@ -1,15 +1,37 @@
 local M = {}
 
-local function get_integrations()
-	local integrations = O["integrations"]
+function M.apply(flavour)
+	flavour = flavour or require("catppuccin").flavour
+
+	local _O, _C, _U = O, C, U -- Borrowing global var (setfenv doesn't work with require)
+	O = require("catppuccin").options
+	C = require("catppuccin.palettes").get_palette(flavour)
+	U = require "catppuccin.utils.colors"
+
+	C.none = "NONE"
+
+	local dim_percentage = O.dim_inactive.percentage
+	C.dim = O.dim_inactive.shade == "dark"
+			and U.vary_color(
+				{ latte = U.darken(C.base, dim_percentage, C.mantle) },
+				U.darken(C.base, dim_percentage, C.mantle)
+			)
+		or U.vary_color(
+			{ latte = U.lighten("#FBFCFD", dim_percentage, C.base) },
+			U.lighten(C.surface0, dim_percentage, C.base)
+		)
+
+	local theme = {}
+	theme.syntax = require("catppuccin.groups.syntax").get()
+	theme.editor = require("catppuccin.groups.editor").get()
 	local final_integrations = {}
 
-	for integration in pairs(integrations) do
+	for integration in pairs(O.integrations) do
 		local cot = false
-		if type(integrations[integration]) == "table" then
-			if integrations[integration]["enabled"] == true then cot = true end
+		if type(O.integrations[integration]) == "table" then
+			if O.integrations[integration].enabled == true then cot = true end
 		else
-			if integrations[integration] == true then cot = true end
+			if O.integrations[integration] == true then cot = true end
 		end
 
 		if cot then
@@ -20,52 +42,19 @@ local function get_integrations()
 			)
 		end
 	end
+	theme.integrations = final_integrations -- plugins
+	theme.terminal = require("catppuccin.groups.terminal").get() -- terminal colors
+	local user_highlights = O.highlight_overrides
+	if type(user_highlights[flavour]) == "function" then user_highlights[flavour] = user_highlights[flavour](C) end
+	theme.custom_highlights = vim.tbl_deep_extend(
+		"keep",
+		user_highlights[flavour] or {},
+		type(user_highlights.all) == "function" and user_highlights.all(C) or user_highlights.all or {}
+	)
 
-	return final_integrations
-end
+	O, C, U = _O, _C, _U -- Returning global var
 
-function M.apply(flavour)
-	flavour = flavour or require("catppuccin").flavour
-
-	local env = {
-		O = require("catppuccin").options,
-		C = require("catppuccin.palattes").get_palette(flavour),
-		U = require "catppuccin.utils.colors",
-	}
-
-	setmetatable(env, { __index = _G })
-
-	local function theme_with_env()
-		C.none = "NONE"
-
-		local dim_percentage = O.dim_inactive.percentage
-		C.dim = O.dim_inactive.shade == "dark"
-				and U.vary_color(
-					{ latte = U.darken(C.base, dim_percentage, C.mantle) },
-					U.darken(C.base, dim_percentage, C.mantle)
-				)
-			or U.vary_color(
-				{ latte = U.lighten("#FBFCFD", dim_percentage, C.base) },
-				U.lighten(C.surface0, dim_percentage, C.base)
-			)
-
-		local theme = {}
-		theme.syntax = require("catppuccin.groups.syntax").get()
-		theme.editor = require("catppuccin.groups.editor").get()
-		theme.integrations = get_integrations() -- plugins
-		theme.terminal = require("catppuccin.groups.terminal").get() -- terminal colors
-		local user_highlights = require("catppuccin").options.highlight_overrides
-		if type(user_highlights[flavour]) == "function" then user_highlights[flavour] = user_highlights[flavour](C) end
-		theme.custom_highlights = vim.tbl_deep_extend(
-			"keep",
-			user_highlights[flavour] or {},
-			type(user_highlights.all) == "function" and user_highlights.all(C) or user_highlights.all or {}
-		)
-
-		return theme
-	end
-
-	return setfenv(theme_with_env, env)()
+	return theme
 end
 
 return M

--- a/lua/catppuccin/lib/mapper.lua
+++ b/lua/catppuccin/lib/mapper.lua
@@ -40,10 +40,10 @@ function M.apply(flavour)
 
 		local dim_percentage = O.dim_inactive.percentage
 		C.dim = O.dim_inactive.shade == "dark"
-			and U.vary_color(
-				{ latte = U.darken(C.base, dim_percentage, C.mantle) },
-				U.darken(C.base, dim_percentage, C.mantle)
-			)
+				and U.vary_color(
+					{ latte = U.darken(C.base, dim_percentage, C.mantle) },
+					U.darken(C.base, dim_percentage, C.mantle)
+				)
 			or U.vary_color(
 				{ latte = U.lighten("#FBFCFD", dim_percentage, C.base) },
 				U.lighten(C.surface0, dim_percentage, C.base)
@@ -52,7 +52,7 @@ function M.apply(flavour)
 		local theme = {}
 		theme.syntax = require("catppuccin.groups.syntax").get()
 		theme.editor = require("catppuccin.groups.editor").get()
-		theme.integrations = get_integrations()                -- plugins
+		theme.integrations = get_integrations() -- plugins
 		theme.terminal = require("catppuccin.groups.terminal").get() -- terminal colors
 		local user_highlights = require("catppuccin").options.highlight_overrides
 		if type(user_highlights[flavour]) == "function" then user_highlights[flavour] = user_highlights[flavour](C) end

--- a/vim.yml
+++ b/vim.yml
@@ -37,6 +37,13 @@ globals:
     args:
       - type: function
 
+  C:
+    property: full-write
+  O:
+    property: full-write
+  U:
+    property: full-write
+
   C.rosewater:
     type: string
     property: read-only


### PR DESCRIPTION
This uses Lua's environment features in order to modify global scope for loading hlgroups instead of the old hacky solution which modified `_G`.