### PR TITLE
feat(integrations): accept both boolean and table config

### DIFF
--- a/lua/catppuccin/groups/integrations/navic.lua
+++ b/lua/catppuccin/groups/integrations/navic.lua
@@ -1,10 +1,9 @@
 local M = {}
--- Backwards compatibility
-if type(O.integrations.navic) == "boolean" then O.integrations.navic = { custom_bg = C.mantle } end
-
-local background = O.integrations.navic.custom_bg and O.integrations.navic.custom_bg or C.none
 
 function M.get()
+	local background = O.integrations.navic.custom_bg and O.integrations.navic.custom_bg or C.none
+	if O.integrations.navic.custom_bg == "lualine" then background = C.mantle end
+
 	return {
 		NavicIconsFile = { fg = C.blue, bg = background },
 		NavicIconsModule = { fg = C.blue, bg = background },

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -1,35 +1,7 @@
 local M = {}
 
 function M.get()
-	-- Backwards compatibility
-	if type(O.integrations.telescope) == "boolean" then
-		return {
-			-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
-			TelescopeBorder = { link = "FloatBorder" },
-			TelescopeSelectionCaret = { fg = C.flamingo },
-			TelescopeSelection = {
-				fg = O.transparent_background and C.flamingo or C.text,
-				bg = O.transparent_background and C.none or C.surface0,
-				style = { "bold" },
-			},
-			TelescopeMatching = { fg = C.blue },
-		}
-	end
-
-	if O.integrations.telescope.style == "classic" then
-		-- Classic look
-		return {
-			-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
-			TelescopeBorder = { link = "FloatBorder" },
-			TelescopeSelectionCaret = { fg = C.flamingo },
-			TelescopeSelection = {
-				fg = O.transparent_background and C.flamingo or C.text,
-				bg = O.transparent_background and C.none or C.surface0,
-				style = { "bold" },
-			},
-			TelescopeMatching = { fg = C.blue },
-		}
-	elseif O.integrations.telescope.style == "nvchad" then
+	if O.integrations.telescope.style == "nvchad" then
 		-- Flat look
 		return {
 			TelescopePromptPrefix = { bg = C.crust },
@@ -45,6 +17,18 @@ function M.get()
 			TelescopePreviewTitle = { bg = C.lavender, fg = C.base, bold = true },
 		}
 	end
+
+	return {
+		-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
+		TelescopeBorder = { link = "FloatBorder" },
+		TelescopeSelectionCaret = { fg = C.flamingo },
+		TelescopeSelection = {
+			fg = O.transparent_background and C.flamingo or C.text,
+			bg = O.transparent_background and C.none or C.surface0,
+			style = { "bold" },
+		},
+		TelescopeMatching = { fg = C.blue },
+	}
 end
 
 return M

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -3,7 +3,7 @@ if is_vim then require "catppuccin.lib.vim" end
 
 ---@type Catppuccin
 local M = {
-	options = {
+	default_options = {
 		background = {
 			light = "latte",
 			dark = "mocha",
@@ -43,10 +43,7 @@ local M = {
 			nvimtree = true,
 			rainbow_delimiters = true,
 			semantic_tokens = not is_vim,
-			telescope = {
-				enabled = true,
-				style = "classic",
-			},
+			telescope = { enabled = true },
 			treesitter = not is_vim,
 			ts_rainbow = true,
 			ts_rainbow2 = true,
@@ -143,7 +140,7 @@ function M.setup(user_conf)
 	did_setup = true
 	-- Parsing user config
 	user_conf = user_conf or {}
-	M.options = vim.tbl_deep_extend("keep", user_conf, M.options)
+	M.options = vim.tbl_deep_extend("keep", user_conf, M.default_options)
 	M.options.highlight_overrides.all = user_conf.custom_highlights or M.options.highlight_overrides.all
 
 	-- Get cached hash

--- a/lua/catppuccin/lib/mapper.lua
+++ b/lua/catppuccin/lib/mapper.lua
@@ -31,7 +31,11 @@ function M.apply(flavour)
 		if type(O.integrations[integration]) == "table" then
 			if O.integrations[integration].enabled == true then cot = true end
 		else
-			if O.integrations[integration] == true then cot = true end
+			if O.integrations[integration] == true then
+				O.integrations[integration] = require("catppuccin").default_options[integration] or {}
+				O.integrations[integration].enabled = true
+				cot = true
+			end
 		end
 
 		if cot then


### PR DESCRIPTION
Both of these configs are valid:

<table>
<tr>
<td> Boolean </td> <td> Table </td>
</tr>
<tr>
<td>

```lua
integrations = {
  navic = true,
  telescope = true,
  dropbar = true,
},
```
</td>
<td>

```lua
integrations = {
  navic = {
    enabled = true,
    custom_bg = "lualine",
  },
  telescope = {
    enabled = true,
    style = "nvchad",
  },
  dropbar = {
    enabled = true,
    color_mode = true,
  },
},
```
</td>
</tr>
</table>

