### PR TITLE
feat(telescope): make nvchad style great again

### DIFF
--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -32,7 +32,7 @@ function M.get()
 			},
 			TelescopeResultsTitle = {
 				fg = C.mantle,
-				bg = O.transparent_background and C.none or C.mantle,
+				bg = O.transparent_background and C.none or C.lavender,
 			},
 			TelescopeSelection = {
 				fg = O.transparent_background and C.subtext0 or C.text,

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -2,19 +2,42 @@ local M = {}
 
 function M.get()
 	if O.integrations.telescope.style == "nvchad" then
-		-- Flat look
 		return {
-			TelescopePromptPrefix = { bg = C.crust },
-			TelescopeSelectionCaret = { fg = C.rosewater, bg = C.surface1, bold = true },
-			TelescopePromptNormal = { bg = C.crust },
-			TelescopeResultsNormal = { bg = C.mantle },
-			TelescopePreviewNormal = { bg = C.mantle },
-			TelescopePromptBorder = { bg = C.crust, fg = C.crust },
-			TelescopeResultsBorder = { bg = C.mantle, fg = C.mantle },
-			TelescopePreviewBorder = { bg = C.mantle, fg = C.mantle },
-			TelescopePromptTitle = { bg = C.rosewater, fg = C.base, bold = true },
-			TelescopeResultsTitle = { bg = C.rosewater, fg = C.base, bold = true },
-			TelescopePreviewTitle = { bg = C.lavender, fg = C.base, bold = true },
+			TelescopeBorder = {
+				fg = O.transparent_background and C.blue or C.mantle,
+				bg = O.transparent_background and C.none or C.mantle,
+			},
+			TelescopePromptBorder = {
+				fg = O.transparent_background and C.blue or C.surface0,
+				bg = O.transparent_background and C.none or C.surface0,
+			},
+			TelescopePromptNormal = {
+				fg = C.text,
+				bg = O.transparent_background and C.none or C.surface0,
+			},
+			TelescopePromptPrefix = {
+				fg = C.flamingo,
+				bg = O.transparent_background and C.none or C.surface0,
+			},
+			TelescopeNormal = {
+				bg = O.transparent_background and C.none or C.mantle,
+			},
+			TelescopePreviewTitle = {
+				fg = O.transparent_background and C.green or C.base,
+				bg = O.transparent_background and C.none or C.green,
+			},
+			TelescopePromptTitle = {
+				fg = O.transparent_background and C.red or C.base,
+				bg = O.transparent_background and C.none or C.red,
+			},
+			TelescopeResultsTitle = {
+				fg = C.mantle,
+				bg = O.transparent_background and C.none or C.mantle,
+			},
+			TelescopeSelection = {
+				fg = O.transparent_background and C.subtext0 or C.text,
+				bg = O.transparent_background and C.none or C.surface0,
+			},
 		}
 	end
 


### PR DESCRIPTION
Credit: [ayamir/nvimdots](https://github.com/ayamir/nvimdots/blob/99bc229cf688fab95eb8c48e6ff260c3287b7950/lua/modules/configs/ui/catppuccin.lua#L150)

cc @vollowx @axieax

# Before

`results_title = false`

![image](https://github.com/catppuccin/nvim/assets/56817415/cda43c93-aaca-40b2-b253-e6232318d6df)

`results_title = true`

![image](https://github.com/catppuccin/nvim/assets/56817415/b0dfa67b-00c0-462f-83bf-ce3bed935032)

# After

`results_title = false`

![image](https://github.com/catppuccin/nvim/assets/56817415/4290f146-50bb-4bdd-968b-c0a54d883e7e)

`results_title = true`

![image](https://github.com/catppuccin/nvim/assets/56817415/394ce3d5-dd42-4a02-83d0-5682f1118d69)

