### PR TITLE
feat: add ability to enable/disable all integrations by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ require("catppuccin").setup({
     },
     color_overrides = {},
     custom_highlights = {},
+    integration_default = nil, -- set to true/false to enable/disable integrations by default
     integrations = {
         cmp = true,
         gitsigns = true,

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -102,6 +102,7 @@ options and settings.
         },
         color_overrides = {},
         custom_highlights = {},
+        integration_default = nil, -- set to true/false to enable/disable integrations by default
         integrations = {
             cmp = true,
             gitsigns = true,

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -141,7 +141,18 @@ function M.setup(user_conf)
 	did_setup = true
 	-- Parsing user config
 	user_conf = user_conf or {}
-	M.options = vim.tbl_deep_extend("keep", user_conf, M.default_options)
+	local options = M.default_options
+	if user_conf.integration_default ~= nil then
+		options = vim.deepcopy(M.default_options)
+		for key, _ in pairs(options.integrations) do
+			if type(options.integrations[key]) == "table" then
+				options.integrations[key].enabled = user_conf.integration_default
+			else
+				options.integrations[key] = user_conf.integration_default
+			end
+		end
+	end
+	M.options = vim.tbl_deep_extend("keep", user_conf, options)
 	M.options.highlight_overrides.all = user_conf.custom_highlights or M.options.highlight_overrides.all
 
 	-- Get cached hash

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -29,6 +29,9 @@
 ---@field no_underline boolean
 -- Handles the style of general hl groups (see `:h highlight-groups`).
 ---@field styles CtpStyles
+-- Control default of integrations. `true` enables all integrations and `false` disables all integrations
+-- If `nil`, use the defaults provided by Catppuccin
+---@field integration_default boolean?
 -- Toggle integrations. Integrations allow Catppuccin to set the theme of various plugins.
 ---@field integrations CtpIntegrations
 -- Catppuccin colors can be overwritten here.


### PR DESCRIPTION
This adds a new configuration option that allows the user to easily enable/disable all of the included integrations by default.