### PR TITLE
chore: update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ Here are some guidelines:
 - New plugin integration should be added in alphabetical order:
   - to the [README](https://github.com/catppuccin/nvim#integrations) (vimdoc is auto-generated).
   - to [types.lua](https://github.com/catppuccin/nvim/blob/main/lua/catppuccin/types.lua)
+  - to [vim.yml](https://github.com/catppuccin/nvim/blob/main/vim.yml)
 - Create a topic branch on your fork for your specific PR.
 - Use [conventionalcommits.org's](https://www.conventionalcommits.org/en/v1.0.0/) 
   rules for explicit and meaningful commit messages.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,13 @@
-🎉 First off, thanks for taking the time to contribute! 🎉 Here are some guidelines from us:
+🎉 First off, thanks for taking the time to contribute! 🎉
+
+Here are some guidelines:
 - Format code using [stylua](https://github.com/johnnymorganz/stylua).
-- New plugin integration should be added in [alphabetical order](https://github.com/catppuccin/nvim#integrations)
-- Recommendation:
-  - Create a topic branch on your fork for your specific PR.
-  - Consider using [conventionalcommits.org's](https://www.conventionalcommits.org/en/v1.0.0/) rules for creating explicit and meaningful commit messages.
-  - If it's your first time contributing to a project then read [About pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) on Github's docs.
+- New plugin integration should be added in alphabetical order:
+  - to the [README](https://github.com/catppuccin/nvim#integrations) (vimdoc is auto-generated).
+  - to [types.lua](https://github.com/catppuccin/nvim/blob/main/lua/catppuccin/types.lua)
+- Create a topic branch on your fork for your specific PR.
+- Use [conventionalcommits.org's](https://www.conventionalcommits.org/en/v1.0.0/) 
+  rules for explicit and meaningful commit messages.
+- If it's your first time contributing to a project, then read 
+  [About pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) 
+  on Github's docs.


### PR DESCRIPTION
Changes wording for our PR template:
- `types.lua` is added, so we don't have to play catch up with new integrations again.
- Mention that our vimdoc is auto-generated, so people don't change it manually
- Since 9d562c161ef6febbef1d04eef111882a176c651e we're using release-please, so we should enforce Conventional Commits rather than just recommending them.