### PR TITLE
fix: don't highlight fg of `PmenuSel`

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -44,7 +44,7 @@ function M.get()
 			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or U.darken(C.surface0, 0.8, C.crust),
 			fg = C.overlay2,
 		}, -- Popup menu: normal item.
-		PmenuSel = { fg = C.text, bg = C.surface1, style = { "bold" } }, -- Popup menu: selected item.
+		PmenuSel = { bg = C.surface1, style = { "bold" } }, -- Popup menu: selected item.
 		PmenuSbar = { bg = C.surface1 }, -- Popup menu: scrollbar.
 		PmenuThumb = { bg = C.overlay0 }, -- Popup menu: Thumb of the scrollbar.
 		Question = { fg = C.blue }, -- |hit-enter| prompt and yes/no questions


### PR DESCRIPTION
This fixes an issue where certain colors were being overrided in selection menus. In my case this was interferring with plugins like [tailwindcss-colorizer-cmp.nvim](https://github.com/roobert/tailwindcss-colorizer-cmp.nvim) and [cmp-tailwind-colors](https://github.com/js-everts/cmp-tailwind-colors).

A lot of other colorscheme plugins like tokyonight don't set the fg color for `PmenuSel`, so I'd assume this shouldn't cause problems, but please let me know if this was actually intentional.

Before:
<img width="194" alt="image" src="https://github.com/catppuccin/nvim/assets/56745535/ab6d6fe8-46bc-4485-8306-86399e360a81">
<img width="229" alt="image" src="https://github.com/catppuccin/nvim/assets/56745535/ac04bf98-76e7-4b11-85b1-cf7c0cfa57e9">


After:
<img width="213" alt="image" src="https://github.com/catppuccin/nvim/assets/56745535/f213c366-81ea-480f-a349-e3e6d00bf171">
<img width="230" alt="image" src="https://github.com/catppuccin/nvim/assets/56745535/738e7fff-df11-4268-80b5-73c66e360ded">

