### PR TITLE
feat(treesitter-context): add color for normal background

### DIFF
--- a/lua/catppuccin/groups/integrations/treesitter_context.lua
+++ b/lua/catppuccin/groups/integrations/treesitter_context.lua
@@ -1,7 +1,9 @@
 local M = {}
 
 function M.get()
-	return O.transparent_background and { TreesitterContextBottom = { sp = C.dim, style = { "underline" } } } or {}
+	return O.transparent_background and {
+		TreesitterContextBottom = { sp = C.dim, style = { "underline" } },
+	} or {}
 end
 
 return M

--- a/lua/catppuccin/groups/integrations/treesitter_context.lua
+++ b/lua/catppuccin/groups/integrations/treesitter_context.lua
@@ -3,7 +3,12 @@ local M = {}
 function M.get()
 	return O.transparent_background and {
 		TreesitterContextBottom = { sp = C.dim, style = { "underline" } },
-	} or {}
+	} or {
+		TreesitterContextLineNumber = {
+			fg = C.surface1,
+			bg = C.mantle,
+		},
+	}
 end
 
 return M

--- a/lua/catppuccin/groups/integrations/treesitter_context.lua
+++ b/lua/catppuccin/groups/integrations/treesitter_context.lua
@@ -4,6 +4,10 @@ function M.get()
 	return O.transparent_background and {
 		TreesitterContextBottom = { sp = C.dim, style = { "underline" } },
 	} or {
+		TreesitterContextBottom = {
+			sp = C.surface0,
+			style = { "underline" },
+		},
 		TreesitterContextLineNumber = {
 			fg = C.surface1,
 			bg = C.mantle,


### PR DESCRIPTION
The only effect of the former treesitter-context support is to add a border-bottom when the `transparent_background` is on.

This PR adds two highlights for normal background, one for a looming border-bottom, and one for the line number.

Former:

![image](https://github.com/catppuccin/nvim/assets/61115159/43a3ea3e-d9f8-4734-9765-6ce79417f02b)


Current:

![image](https://github.com/catppuccin/nvim/assets/61115159/c917407f-feaa-4df8-842e-574841972463)

NOTE: The `TreesitterContextLineNumber` should not be configured in catppuccin because the nvim-treesitter-context provided an option to decide whether accept this highlight.