### PR TITLE
Add `nvim-window-picker` integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1094,7 +1094,7 @@ ts_rainbow = true
 <td>
 
 ```lua
-window_picker = true
+window_picker = false
 ```
 
 <!-- octo.nvim -->

--- a/README.md
+++ b/README.md
@@ -1087,6 +1087,16 @@ ts_rainbow = true
 </tr>
 <!-- nvim-ts-rainbow -->
 
+<!-- nvim-window-picker -->
+</tr>
+<tr>
+<td> <a href="https://github.com/s1n7ax/nvim-window-picker">nvim-window-picker</a> </td>
+<td>
+
+```lua
+window_picker = true
+```
+
 <!-- octo.nvim -->
 </tr>
 <tr>

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -297,8 +297,8 @@ Update your bufferline config to use the Catppuccin components:
     }
 <
 
-Configurations are self-explanatory, see `:h bufferline-highlights` for
-detailed explanations:
+Configurations are self-explanatory, see |bufferline-highlights| for detailed
+explanations:
 
 >lua
     local mocha = require("catppuccin.palettes").get_palette "mocha"
@@ -691,6 +691,10 @@ nvim-ts-rainbow2>lua
 
 nvim-ts-rainbow>lua
     ts_rainbow = true
+<
+
+nvim-window-picker>lua
+    window_picker = true
 <
 
 octo.nvim>lua

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -694,7 +694,7 @@ nvim-ts-rainbow>lua
 <
 
 nvim-window-picker>lua
-    window_picker = true
+    window_picker = false
 <
 
 octo.nvim>lua

--- a/lua/catppuccin/groups/integrations/window_picker.lua
+++ b/lua/catppuccin/groups/integrations/window_picker.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+function M.get()
+	return {
+		WindowPickerStatusLine = { C.red, style = { "bold" } },
+		WindowPickerStatusLineNC = { C.red, style = { "bold" } },
+		WindowPickerWinBar = { C.red, style = { "bold" } },
+		WindowPickerWinBarNC = { C.red, style = { "bold" } },
+	}
+end
+
+return M

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -194,6 +194,7 @@
 ---@field vim_sneak boolean?
 ---@field vimwiki boolean?
 ---@field which_key boolean?
+---@field window_picker boolean?
 
 ---@class CtpIntegrationBarbecue
 --  Whether to use the alternative background.

--- a/vim.yml
+++ b/vim.yml
@@ -258,6 +258,10 @@ globals:
     type: bool
     property: read-only
 
+  O.integrations.window_picker:
+    type: bool
+    property: read-only
+
   O.integrations.barbecue.dim_dirname:
     type: bool
     property: read-only


### PR DESCRIPTION
This adds integration for [nvim-window-picker](https://github.com/s1n7ax/nvim-window-picker). It is used by `neo-tree` and they recently added the ability to configure the colors through highlight groups.