### PR TITLE
feat(gitsigns): support GitSignsCurrentLineBlame highlights

### DIFF
--- a/lua/catppuccin/groups/integrations/gitsigns.lua
+++ b/lua/catppuccin/groups/integrations/gitsigns.lua
@@ -11,6 +11,8 @@ function M.get()
 			GitSignsChange = { fg = C.yellow }, -- diff mode: Changed line |diff.txt|
 			GitSignsDelete = { fg = C.red }, -- diff mode: Deleted line |diff.txt|
 
+			GitSignsCurrentLineBlame = { fg = C.surface1 },
+
 			GitSignsAddPreview = O.transparent_background and { fg = U.darken(C.green, 0.72, C.base), bg = C.none }
 				or { link = "DiffAdd" },
 			GitSignsDeletePreview = O.transparent_background and { fg = U.darken(C.red, 0.72, C.base), bg = C.none }
@@ -39,6 +41,8 @@ function M.get()
 			GitSignsAdd = { fg = C.green }, -- diff mode: Added line |diff.txt|
 			GitSignsChange = { fg = C.yellow }, -- diff mode: Changed line |diff.txt|
 			GitSignsDelete = { fg = C.red }, -- diff mode: Deleted line |diff.txt|
+
+			GitSignsCurrentLineBlame = { fg = C.surface1 },
 
 			GitSignsAddPreview = O.transparent_background and { fg = C.green, bg = C.none } or { link = "DiffAdd" },
 			GitSignsDeletePreview = O.transparent_background and { fg = C.red, bg = C.none } or { link = "DiffDelete" },


### PR DESCRIPTION
## Description

I found that the fg color of `GitSignsCurrentLineBlame` and `Comment` are the same, which sometimes confuses me:

The Comment fg color is `overlay0` now:
<img width="1266" alt="image" src="https://github.com/catppuccin/nvim/assets/36906329/5c68a93f-aabb-477e-abf9-88d644c328ae">

https://github.com/catppuccin/nvim/blob/dae42a0abe01b2f3e3029f203866c6673099745a/lua/catppuccin/groups/syntax.lua#L5

`GitSignsCurrentLineBlame` is mapped to `NonText`:

https://github.com/lewis6991/gitsigns.nvim/blob/749267aaa863c30d721c9913699c5d94e0c07dd3/lua/gitsigns/highlight.lua#L174

And, `NonText` fg color is same with `Comment`:

https://github.com/catppuccin/nvim/blob/dae42a0abe01b2f3e3029f203866c6673099745a/lua/catppuccin/groups/editor.lua#L30

## What problem does this PR solve?

This PR distinguishes the two, making the `GitSignsCurrentLineBlame` dimmer and making it easier to distinguish between the two.

## Actual effect

### Latte

* before
<img width="1283" alt="image" src="https://github.com/catppuccin/nvim/assets/36906329/4e72a05e-bee2-4c52-be8a-0b20ed3c926a">

* after
<img width="1269" alt="image" src="https://github.com/catppuccin/nvim/assets/36906329/b540a582-018a-40b2-9cae-12a62f1e30e2">


### Frappe

* before
<img width="1276" alt="image" src="https://github.com/catppuccin/nvim/assets/36906329/f2ae33c1-9f34-40a9-b4d6-1b64fcd21daf">

* after
<img width="1275" alt="image" src="https://github.com/catppuccin/nvim/assets/36906329/8cdbbb35-e6ca-469e-8642-00cc17ae0beb">


### Macchiato

* before
<img width="1272" alt="image" src="https://github.com/catppuccin/nvim/assets/36906329/444af9fd-e679-4564-9b3d-054160785aa3">

* after
<img width="1275" alt="image" src="https://github.com/catppuccin/nvim/assets/36906329/26917a30-c3b2-4f6c-85f2-7b6cb77758ad">


### Mocha

* before
<img width="1272" alt="image" src="https://github.com/catppuccin/nvim/assets/36906329/5d00f26b-b2fa-4b90-aa45-957818008834">

* after
<img width="1273" alt="image" src="https://github.com/catppuccin/nvim/assets/36906329/c7e590cd-d0a8-4328-a649-7385d02b6d9b">

