### PR TITLE
Fix missing table keys in nvim-window-picker integration

### DIFF
--- a/lua/catppuccin/groups/integrations/window_picker.lua
+++ b/lua/catppuccin/groups/integrations/window_picker.lua
@@ -2,10 +2,10 @@ local M = {}
 
 function M.get()
 	return {
-		WindowPickerStatusLine = { C.red, style = { "bold" } },
-		WindowPickerStatusLineNC = { C.red, style = { "bold" } },
-		WindowPickerWinBar = { C.red, style = { "bold" } },
-		WindowPickerWinBarNC = { C.red, style = { "bold" } },
+		WindowPickerStatusLine = { fg = C.red, style = { "bold" } },
+		WindowPickerStatusLineNC = { fg = C.red, style = { "bold" } },
+		WindowPickerWinBar = { fg = C.red, style = { "bold" } },
+		WindowPickerWinBarNC = { fg = C.red, style = { "bold" } },
 	}
 end
 


### PR DESCRIPTION
Fixes errors raised when using the integration provided in #566.