### PR TITLE
Octo updates

### DIFF
--- a/lua/catppuccin/groups/integrations/octo.lua
+++ b/lua/catppuccin/groups/integrations/octo.lua
@@ -8,7 +8,7 @@ function M.get()
 		OctoGreen = { fg = C.green },
 		OctoRed = { fg = C.red },
 		OctoPurple = { fg = C.mauve },
-		OctoYelow = { fg = C.yellow },
+		OctoYellow = { fg = C.yellow },
 		-- highlight groups
 		OctoDirty = { link = "ErrorMsg" },
 		OctoIssueTitle = { link = "PreProc" },

--- a/lua/catppuccin/groups/integrations/octo.lua
+++ b/lua/catppuccin/groups/integrations/octo.lua
@@ -23,7 +23,6 @@ function M.get()
 		OctoDetailsValue = { link = "Identifier" },
 		OctoDiffHunkPosition = { link = "NormalFloat" },
 		OctoCommentLine = { link = "TabLineSel" },
-		OctoEditable = { fg = C.text, bg = C.mantle },
 		OctoViewer = { fg = C.base, bg = C.blue },
 		OctoBubble = { fg = C.text, bg = C.mantle },
 		OctoBubbleGrey = { fg = C.text, bg = C.mantle },


### PR DESCRIPTION
- Fix type for yellow definition.
- Drop `OctoEditable` group and allow treesitter colors to be shown

Treesitter colors are overwritten if `OctoEditable` by catppuccin.

I tried adding a custom option on the integration, but it would create a breaking change on the config and I don't think is worth the complexity.

See https://github.com/pwntester/octo.nvim/discussions/424 for details on the problem.
