### PR TITLE
feat(mini.indentscope): add scope color

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,10 @@ require("catppuccin").setup({
         nvimtree = true,
         treesitter = true,
         notify = false,
-        mini = false,
+        mini = {
+            enabled = true,
+            indentscope_color = "",
+        },
         -- For more plugins integrations please scroll down (https://github.com/catppuccin/nvim#integrations)
     },
 })
@@ -240,7 +243,10 @@ require("catppuccin").setup({
         nvimtree = true,
         treesitter = true,
         notify = false,
-        mini = false,
+        mini = {
+            enabled = true,
+            indentscope_color = "",
+        },
     }
 })
 ```
@@ -819,7 +825,10 @@ mason = false
 <td>
 
 ```lua
-mini = false
+mini = {
+    enabled = true,
+    indentscope_color = "", -- catppuccin color (eg. `lavender`) Default: text
+},
 ```
 
 </td>

--- a/lua/catppuccin/groups/integrations/mini.lua
+++ b/lua/catppuccin/groups/integrations/mini.lua
@@ -7,12 +7,6 @@ function M.get()
 	local inactive_bg = transparent_background and "NONE" or C.mantle
 
 	local indentscope_color = O.integrations.mini.indentscope_color
-	if C[indentscope_color] then
-		indentscope_color = { fg = C[indentscope_color] }
-	else
-		indentscope_color = { fg = C.text }
-	end
-
 	return {
 		MiniCompletionActiveParameter = { style = { "underline" } },
 

--- a/lua/catppuccin/groups/integrations/mini.lua
+++ b/lua/catppuccin/groups/integrations/mini.lua
@@ -6,13 +6,20 @@ function M.get()
 
 	local inactive_bg = transparent_background and "NONE" or C.mantle
 
+	local indentscope_color = O.integrations.mini.indentscope_color
+	if C[indentscope_color] then
+		indentscope_color = { fg = C[indentscope_color] }
+	else
+		indentscope_color = { fg = C.text }
+	end
+
 	return {
 		MiniCompletionActiveParameter = { style = { "underline" } },
 
 		MiniCursorword = { style = { "underline" } },
 		MiniCursorwordCurrent = { style = { "underline" } },
 
-		MiniIndentscopeSymbol = { fg = C.blue },
+		MiniIndentscopeSymbol = indentscope_color,
 		MiniIndentscopePrefix = { style = { "nocombine" } }, -- Make it invisible
 
 		MiniJump = { fg = C.overlay2, bg = C.pink },

--- a/lua/catppuccin/groups/integrations/mini.lua
+++ b/lua/catppuccin/groups/integrations/mini.lua
@@ -12,7 +12,7 @@ function M.get()
 		MiniCursorword = { style = { "underline" } },
 		MiniCursorwordCurrent = { style = { "underline" } },
 
-		MiniIndentscopeSymbol = { fg = C.text },
+		MiniIndentscopeSymbol = { fg = C.blue },
 		MiniIndentscopePrefix = { style = { "nocombine" } }, -- Make it invisible
 
 		MiniJump = { fg = C.overlay2, bg = C.pink },

--- a/lua/catppuccin/groups/integrations/mini.lua
+++ b/lua/catppuccin/groups/integrations/mini.lua
@@ -19,7 +19,7 @@ function M.get()
 		MiniCursorword = { style = { "underline" } },
 		MiniCursorwordCurrent = { style = { "underline" } },
 
-		MiniIndentscopeSymbol = indentscope_color,
+		MiniIndentscopeSymbol = { fg = C[indentscope_color] and C[indentscope_color] or C.text },
 		MiniIndentscopePrefix = { style = { "nocombine" } }, -- Make it invisible
 
 		MiniJump = { fg = C.overlay2, bg = C.pink },

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -164,7 +164,6 @@
 ---@field lsp_trouble boolean?
 ---@field markdown boolean?
 ---@field mason boolean?
----@field mini boolean?
 ---@field native_lsp CtpIntegrationNativeLsp | boolean?
 -- You **NEED** to enable highlight in your `nvim-navic` config or it won't work:
 --
@@ -227,6 +226,12 @@
 -- Enables char highlights per indent level.
 -- Follow the instructions on the plugins GitHub repo to set it up.
 ---@field colored_indent_levels boolean?
+
+---@class CtpIntegrationMini
+-- Whether to enable the integration.
+---@field enabled boolean
+-- Sets the color of the scope line
+---@field indentscope_color CtpColor?
 
 ---@class CtpIntegrationNativeLsp
 -- Whether to enable the Native LSP integration.

--- a/vim.yml
+++ b/vim.yml
@@ -285,6 +285,13 @@ globals:
     type: bool
     property: read-only
 
+  O.integrations.mini.enabled:
+    type: bool
+    property: read-only
+  O.integrations.mini.indentscope_color:
+    type: string
+    property: read-only
+
   O.integrations.native_lsp.enabled:
     type: bool
     property: read-only


### PR DESCRIPTION
Added feature to let users choose what color they want for their scope indent line.

#585 but for mini's indentscope