### PR TITLE
fix(lualine): match lualine mode colors for insert and terminal

### DIFF
--- a/lua/catppuccin/utils/lualine.lua
+++ b/lua/catppuccin/utils/lualine.lua
@@ -13,12 +13,12 @@ return function(flavour)
 
 	catppuccin.insert = {
 		a = { bg = C.green, fg = C.base, gui = "bold" },
-		b = { bg = C.surface1, fg = C.teal },
+		b = { bg = C.surface1, fg = C.green },
 	}
 
 	catppuccin.terminal = {
 		a = { bg = C.green, fg = C.base, gui = "bold" },
-		b = { bg = C.surface1, fg = C.teal },
+		b = { bg = C.surface1, fg = C.green },
 	}
 
 	catppuccin.command = {


### PR DESCRIPTION
other modes share the colors for bg and fg:

- <img width="391" alt="image" src="https://github.com/catppuccin/nvim/assets/385877/58f3a6ef-21d1-4cb9-9436-9d6881dfcd20">
- <img width="396" alt="image" src="https://github.com/catppuccin/nvim/assets/385877/24601f12-d0a9-4aa5-9b2e-398c561e2718">

this just updates the two green modes to match

before
<img width="397" alt="image" src="https://github.com/catppuccin/nvim/assets/385877/f4df71b7-59c6-4925-a8f7-760cb90cd4a9">

after
<img width="394" alt="image" src="https://github.com/catppuccin/nvim/assets/385877/205b38c0-83e0-4118-8263-67655244c5f7">
