### PR TITLE
feat(treesitter): follow upstream captures

### DIFF
--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -13,21 +13,18 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 	end
 
 	local colors = { -- Reference: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md
+		-- Identifiers
+		["@variable"] = { fg = C.text, style = O.styles.variables or {} }, -- Any variable name that does not have another highlight.
+		["@variable.builtin"] = { fg = C.red, style = O.styles.properties or {} }, -- Variable names that are defined by the languages, like this or self.
+		["@variable.parameter"] = { fg = C.maroon, style = O.styles.variables or {} }, -- For parameters of a function.
+		["@variable.member"] = { fg = C.lavender }, -- For fields.
 
-		-- Misc
-		["@error"] = { link = "Error" },
-		["@operator"] = { link = "Operator" }, -- For any operator: +, but also -> and * in C.
+		["@constant"] = { link = "Constant" }, -- For constants
+		["@constant.builtin"] = { fg = C.peach, style = O.styles.keywords or {} }, -- For constant that are built in the language: nil in Lua.
+		["@constant.macro"] = { link = "Macro" }, -- For constants that are defined by macros: NULL in C.
 
-		-- Comment
-		["@comment"] = { link = "Comment" },
-		["comment.note"] = { fg = C.base, bg = C.blue },
-		["comment.warning"] = { fg = C.base, bg = C.yellow },
-		["comment.error"] = { fg = C.base, bg = C.red },
-
-		-- Punctuation
-		["@punctuation.delimiter"] = { link = "Delimiter" }, -- For delimiters (e.g. `;` / `.` / `,`).
-		["@punctuation.bracket"] = { fg = C.overlay2 }, -- For brackets and parenthesis.
-		["@punctuation.special"] = { link = "Special" }, -- For special punctuation that does not fall in the categories before (e.g. `{}` in string interpolation).
+		["@module"] = { fg = C.lavender, style = { "italic" } }, -- For identifiers referring to modules and namespaces.
+		["@label"] = { link = "Label" }, -- For labels: label: in C and :label: in Lua.
 
 		-- Literals
 		["@string"] = { link = "String" }, -- For strings.
@@ -41,37 +38,8 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@character.special"] = { link = "SpecialChar" }, -- special characters (e.g. wildcards)
 
 		["@boolean"] = { link = "Boolean" }, -- For booleans.
-
 		["@number"] = { link = "Number" }, -- For all numbers
 		["@number.float"] = { link = "Float" }, -- For floats.
-
-		-- Functions
-		["@function"] = { link = "Function" }, -- For function (calls and definitions).
-		["@function.builtin"] = { fg = C.peach, style = O.styles.functions or {} }, -- For builtin functions: table.insert in Lua.
-		["@function.call"] = { link = "Function" }, -- function calls
-		["@function.macro"] = { fg = C.teal, style = O.styles.functions or {} }, -- For macro defined functions (calls and definitions): each macro_rules in Rust.
-		["@function.method"] = { link = "Function" }, -- For method definitions.
-		["@function.method.call"] = { link = "Function" }, -- For method calls.
-
-		["@constructor"] = { fg = C.sapphire }, -- For constructor calls and definitions: = { } in Lua, and Java constructors.
-
-		-- Keywords
-		["@keyword"] = { link = "Keyword" }, -- For keywords that don't fall in previous categories.
-		["@keyword.function"] = { fg = C.mauve, style = O.styles.keywords or {} }, -- For keywords used to define a function.
-		["@keyword.operator"] = { fg = C.mauve, style = O.styles.operators or {} }, -- For new keyword operator
-		["@keyword.return"] = { fg = C.mauve, style = O.styles.keywords or {} },
-		["@keyword.storage"] = { link = "StorageClass" }, -- visibility/life-time/etc. modifiers (e.g. `static`)
-		["@keyword.directive"] = { link = "PreProc" }, -- various preprocessor directives & shebangs
-		["@keyword.directive.define"] = { link = "Define" }, -- preprocessor definition directives
-		["@keyword.repeat"] = { link = "Repeat" }, -- For keywords related to loops.
-		["@keyword.exception"] = { link = "Exception" }, -- For exception related keywords.
-		["@keyword.import"] = { link = "Include" }, -- For includes: #include in C, use or extern crate in Rust, or require in Lua.
-		["@keyword.conditional"] = { link = "Conditional" }, -- For keywords related to conditionnals.
-		-- JS & derivative
-		["@keyword.export"] = { fg = C.sky, style = O.styles.keywords },
-
-		-- @debug            ; keywords related to debugging
-		["@label"] = { link = "Label" }, -- For labels: label: in C and :label: in Lua.
 
 		-- Types
 		["@type"] = { link = "Type" }, -- For types.
@@ -82,32 +50,64 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@attribute"] = { link = "Constant" }, -- attribute annotations (e.g. Python decorators)
 		["@property"] = { fg = C.lavender, style = O.styles.properties or {} }, -- Same as TSField.
 
-		-- Identifiers
+		-- Functions
+		["@function"] = { link = "Function" }, -- For function (calls and definitions).
+		["@function.builtin"] = { fg = C.peach, style = O.styles.functions or {} }, -- For builtin functions: table.insert in Lua.
+		["@function.call"] = { link = "Function" }, -- function calls
+		["@function.macro"] = { fg = C.teal, style = O.styles.functions or {} }, -- For macro defined functions (calls and definitions): each macro_rules in Rust.
 
-		["@variable"] = { fg = C.text, style = O.styles.variables or {} }, -- Any variable name that does not have another highlight.
-		["@variable.builtin"] = { fg = C.red, style = O.styles.properties or {} }, -- Variable names that are defined by the languages, like this or self.
-		["@variable.parameter"] = { fg = C.maroon, style = O.styles.variables or {} }, -- For parameters of a function.
-		["@variable.member"] = { fg = C.lavender }, -- For fields.
+		["@function.method"] = { link = "Function" }, -- For method definitions.
+		["@function.method.call"] = { link = "Function" }, -- For method calls.
 
-		["@constant"] = { link = "Constant" }, -- For constants
-		["@constant.builtin"] = { fg = C.peach, style = O.styles.keywords or {} }, -- For constant that are built in the language: nil in Lua.
-		["@constant.macro"] = { link = "Macro" }, -- For constants that are defined by macros: NULL in C.
+		["@constructor"] = { fg = C.sapphire }, -- For constructor calls and definitions: = { } in Lua, and Java constructors.
+		["@operator"] = { link = "Operator" }, -- For any operator: +, but also -> and * in C.
 
-		["@module"] = { fg = C.lavender, style = { "italic" } }, -- For identifiers referring to modules and namespaces.
+		-- Keywords
+		["@keyword"] = { link = "Keyword" }, -- For keywords that don't fall in previous categories.
+		["@keyword.function"] = { fg = C.mauve, style = O.styles.keywords or {} }, -- For keywords used to define a function.
+		["@keyword.operator"] = { fg = C.mauve, style = O.styles.operators or {} }, -- For new keyword operator
+		["@keyword.import"] = { link = "Include" }, -- For includes: #include in C, use or extern crate in Rust, or require in Lua.
+		["@keyword.storage"] = { link = "StorageClass" }, -- visibility/life-time/etc. modifiers (e.g. `static`)
+		["@keyword.repeat"] = { link = "Repeat" }, -- For keywords related to loops.
+		["@keyword.return"] = { fg = C.mauve, style = O.styles.keywords or {} },
+		["@keyword.exception"] = { link = "Exception" }, -- For exception related keywords.
 
-		-- Text
+		["@keyword.conditional"] = { link = "Conditional" }, -- For keywords related to conditionnals.
+
+		["@keyword.directive"] = { link = "PreProc" }, -- various preprocessor directives & shebangs
+		["@keyword.directive.define"] = { link = "Define" }, -- preprocessor definition directives
+		-- JS & derivative
+		["@keyword.export"] = { fg = C.sky, style = O.styles.keywords },
+
+		-- Punctuation
+		["@punctuation.delimiter"] = { link = "Delimiter" }, -- For delimiters (e.g. `;` / `.` / `,`).
+		["@punctuation.bracket"] = { fg = C.overlay2 }, -- For brackets and parenthesis.
+		["@punctuation.special"] = { link = "Special" }, -- For special punctuation that does not fall in the categories before (e.g. `{}` in string interpolation).
+
+		-- Comment
+		["@comment"] = { link = "Comment" },
+
+		["comment.error"] = { fg = C.base, bg = C.red },
+		["comment.warning"] = { fg = C.base, bg = C.yellow },
+		["comment.note"] = { fg = C.base, bg = C.blue },
+
+		-- Markup
 		["@markup"] = { fg = C.text }, -- For strings considerated text in a markup language.
 		["@markup.strong"] = { fg = C.maroon, style = { "bold" } }, -- bold
 		["@markup.italic"] = { fg = C.maroon, style = { "italic" } }, -- italic
-		["@markup.underline"] = { link = "Underline" }, -- underlined text
 		["@markup.strikethrough"] = { fg = C.text, style = { "strikethrough" } }, -- strikethrough text
+		["@markup.underline"] = { link = "Underline" }, -- underlined text
+
 		["@markup.heading"] = { fg = C.blue, style = { "bold" } }, -- titles like: # Example
-		["@markup.raw"] = { fg = C.teal }, -- used for inline code in markdown and for doc in python (""")
-		["@markup.link.url"] = { fg = C.rosewater, style = { "italic", "underline" } }, -- urls, links and emails
+
 		["@markup.math"] = { fg = C.blue }, -- math environments (e.g. `$ ... $` in LaTeX)
 		["@markup.environment"] = { fg = C.pink }, -- text environments of markup languages
 		["@markup.environment.name"] = { fg = C.blue }, -- text indicating the type of an environment
+
 		["@markup.link"] = { link = "Tag" }, -- text references, footnotes, citations, etc.
+		["@markup.link.url"] = { fg = C.rosewater, style = { "italic", "underline" } }, -- urls, links and emails
+
+		["@markup.raw"] = { fg = C.teal }, -- used for inline code in markdown and for doc in python (""")
 
 		["@markup.list"] = { link = "Special" },
 		["@markup.list.checked"] = { fg = C.green }, -- todo notes
@@ -122,6 +122,9 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@tag"] = { fg = C.mauve }, -- Tags like html tag names.
 		["@tag.attribute"] = { fg = C.teal, style = { "italic" } }, -- Tags like html tag names.
 		["@tag.delimiter"] = { fg = C.sky }, -- Tag delimiter like < > /
+
+		-- Misc
+		["@error"] = { link = "Error" },
 
 		-- Language specific:
 		-- bash

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -87,9 +87,9 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		-- Comment
 		["@comment"] = { link = "Comment" },
 
-		["comment.error"] = { fg = C.base, bg = C.red },
-		["comment.warning"] = { fg = C.base, bg = C.yellow },
-		["comment.note"] = { fg = C.base, bg = C.blue },
+		["@comment.error"] = { fg = C.base, bg = C.red },
+		["@comment.warning"] = { fg = C.base, bg = C.yellow },
+		["@comment.note"] = { fg = C.base, bg = C.blue },
 
 		-- Markup
 		["@markup"] = { fg = C.text }, -- For strings considerated text in a markup language.

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -15,11 +15,15 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 	local colors = { -- Reference: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md
 
 		-- Misc
-		["@comment"] = { link = "Comment" },
 		["@error"] = { link = "Error" },
-		["@preproc"] = { link = "PreProc" }, -- various preprocessor directives & shebangs
 		["@define"] = { link = "Define" }, -- preprocessor definition directives
 		["@operator"] = { link = "Operator" }, -- For any operator: +, but also -> and * in C.
+
+		-- Comment
+		["@comment"] = { link = "Comment" },
+		["comment.note"] = { fg = C.base, bg = C.blue },
+		["comment.warning"] = { fg = C.base, bg = C.yellow },
+		["comment.error"] = { fg = C.base, bg = C.red },
 
 		-- Punctuation
 		["@punctuation.delimiter"] = { link = "Delimiter" }, -- For delimiters (e.g. `;` / `.` / `,`).
@@ -32,6 +36,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@string.escape"] = { fg = C.pink, style = O.styles.strings or {} }, -- For escape characters within a string.
 		["@string.special"] = { link = "Special" }, -- other special strings (e.g. dates)
 		["@string.special.symbol"] = { fg = C.flamingo },
+		["@string.special.url"] = { fg = C.rosewater, style = { "italic", "underline" } }, -- urls, links and emails
 
 		["@character"] = { link = "Character" }, -- character literals
 		["@character.special"] = { link = "SpecialChar" }, -- special characters (e.g. wildcards)
@@ -46,8 +51,8 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@function.builtin"] = { fg = C.peach, style = O.styles.functions or {} }, -- For builtin functions: table.insert in Lua.
 		["@function.call"] = { link = "Function" }, -- function calls
 		["@function.macro"] = { fg = C.teal, style = O.styles.functions or {} }, -- For macro defined functions (calls and definitions): each macro_rules in Rust.
-		["@method"] = { link = "Function" }, -- For method definitions.
-		["@method.call"] = { link = "Function" }, -- For method calls.
+		["@function.method"] = { link = "Function" }, -- For method definitions.
+		["@function.method.call"] = { link = "Function" }, -- For method calls.
 
 		["@constructor"] = { fg = C.sapphire }, -- For constructor calls and definitions: = { } in Lua, and Java constructors.
 
@@ -56,6 +61,8 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@keyword.function"] = { fg = C.mauve, style = O.styles.keywords or {} }, -- For keywords used to define a function.
 		["@keyword.operator"] = { fg = C.mauve, style = O.styles.operators or {} }, -- For new keyword operator
 		["@keyword.return"] = { fg = C.mauve, style = O.styles.keywords or {} },
+		["@keyword.storage"] = { link = "StorageClass" }, -- visibility/life-time/etc. modifiers (e.g. `static`)
+		["@keyword.directive"] = { link = "PreProc" }, -- various preprocessor directives & shebangs
 		-- JS & derivative
 		["@keyword.export"] = { fg = C.sky, style = O.styles.keywords },
 
@@ -72,9 +79,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@type.definition"] = { link = "Type" }, -- type definitions (e.g. `typedef` in C)
 		["@type.qualifier"] = { link = "Keyword" }, -- type qualifiers (e.g. `const`)
 
-		["@storageclass"] = { link = "StorageClass" }, -- visibility/life-time/etc. modifiers (e.g. `static`)
 		["@attribute"] = { link = "Constant" }, -- attribute annotations (e.g. Python decorators)
-		["@field"] = { fg = C.lavender }, -- For fields.
 		["@property"] = { fg = C.lavender, style = O.styles.properties or {} }, -- Same as TSField.
 
 		-- Identifiers
@@ -82,6 +87,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@variable"] = { fg = C.text, style = O.styles.variables or {} }, -- Any variable name that does not have another highlight.
 		["@variable.builtin"] = { fg = C.red, style = O.styles.properties or {} }, -- Variable names that are defined by the languages, like this or self.
 		["@variable.parameter"] = { fg = C.maroon, style = O.styles.variables or {} }, -- For parameters of a function.
+		["@variable.member"] = { fg = C.lavender }, -- For fields.
 
 		["@constant"] = { link = "Constant" }, -- For constants
 		["@constant.builtin"] = { fg = C.peach, style = O.styles.keywords or {} }, -- For constant that are built in the language: nil in Lua.
@@ -95,23 +101,22 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@markup.emphasis"] = { fg = C.maroon, style = { "italic" } }, -- italic
 		["@markup.underline"] = { link = "Underline" }, -- underlined text
 		["@markup.strike"] = { fg = C.text, style = { "strikethrough" } }, -- strikethrough text
-		["@markup.headline"] = { fg = C.blue, style = { "bold" } }, -- titles like: # Example
+		["@markup.heading"] = { fg = C.blue, style = { "bold" } }, -- titles like: # Example
 		["@markup.raw"] = { fg = C.teal }, -- used for inline code in markdown and for doc in python (""")
-		["@markup.link.uri"] = { fg = C.rosewater, style = { "italic", "underline" } }, -- urls, links and emails
+		["@markup.link.url"] = { fg = C.rosewater, style = { "italic", "underline" } }, -- urls, links and emails
 		["@markup.math"] = { fg = C.blue }, -- math environments (e.g. `$ ... $` in LaTeX)
 		["@markup.environment"] = { fg = C.pink }, -- text environments of markup languages
 		["@markup.environment.name"] = { fg = C.blue }, -- text indicating the type of an environment
 		["@markup.reference"] = { link = "Tag" }, -- text references, footnotes, citations, etc.
 
-		["@markup.todo"] = { fg = C.base, bg = C.yellow }, -- todo notes
-		["@markup.todo.checked"] = { fg = C.green }, -- todo notes
-		["@markup.todo.unchecked"] = { fg = C.overlay1 }, -- todo notes
-		["@markup.note"] = { fg = C.base, bg = C.blue },
-		["@markup.warning"] = { fg = C.base, bg = C.yellow },
-		["@markup.danger"] = { fg = C.base, bg = C.red },
+		["@markup.list"] = { link = "Special" },
+		["@markup.list.checked"] = { fg = C.green }, -- todo notes
+		["@markup.list.unchecked"] = { fg = C.overlay1 }, -- todo notes
 
-		["@markup.diff.add"] = { link = "diffAdded" }, -- added text (for diff files)
-		["@markup.diff.delete"] = { link = "diffRemoved" }, -- deleted text (for diff files)
+		-- Diff
+		["@diff.plus"] = { link = "diffAdded" }, -- added text (for diff files)
+		["@diff.minus"] = { link = "diffRemoved" }, -- deleted text (for diff files)
+		["@diff.delta"] = { link = "diffChanged" }, -- deleted text (for diff files)
 
 		-- Tags
 		["@tag"] = { fg = C.mauve }, -- Tags like html tag names.
@@ -123,12 +128,12 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@function.builtin.bash"] = { fg = C.red, style = { "italic" } },
 
 		-- markdown
-		["@text.title.2.markdown"] = { link = "rainbow2" },
-		["@text.title.1.markdown"] = { link = "rainbow1" },
-		["@text.title.3.markdown"] = { link = "rainbow3" },
-		["@text.title.4.markdown"] = { link = "rainbow4" },
-		["@text.title.5.markdown"] = { link = "rainbow5" },
-		["@text.title.6.markdown"] = { link = "rainbow6" },
+		["@markup.heading.1.markdown"] = { link = "rainbow1" },
+		["@markup.heading.2.markdown"] = { link = "rainbow2" },
+		["@markup.heading.3.markdown"] = { link = "rainbow3" },
+		["@markup.heading.4.markdown"] = { link = "rainbow4" },
+		["@markup.heading.5.markdown"] = { link = "rainbow5" },
+		["@markup.heading.6.markdown"] = { link = "rainbow6" },
 
 		-- java
 		["@constant.java"] = { fg = C.teal },
@@ -160,14 +165,14 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@tag.attribute.tsx"] = { fg = C.mauve, style = { "italic" } },
 
 		-- yaml
-		["@field.yaml"] = { fg = C.blue }, -- For fields.
+		["@variable.member.yaml"] = { fg = C.blue }, -- For fields.
 
 		-- Ruby
 		["@string.special.symbol.ruby"] = { fg = C.flamingo },
 
 		-- PHP
-		["@method.php"] = { link = "Function" },
-		["@method.call.php"] = { link = "Function" },
+		["@function.method.php"] = { link = "Function" },
+		["@function.method.call.php"] = { link = "Function" },
 
 		-- C/CPP
 		["@type.builtin.c"] = { fg = C.yellow, style = {} },
@@ -181,6 +186,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 	-- Legacy highlights
 	colors["@parameter"] = colors["@variable.parameter"]
+	colors["@field"] = colors["@variable.member"]
 	colors["@namespace"] = colors["@module"]
 	colors["@float"] = colors["number.float"]
 	colors["@symbol"] = colors["@string.special.symbol"]
@@ -191,25 +197,51 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 	colors["@text.emphasis"] = colors["@markup.emphasis"]
 	colors["@text.underline"] = colors["@markup.underline"]
 	colors["@text.strike"] = colors["@markup.strike"]
-	colors["@text.title"] = colors["@markup.headline"]
-	colors["@text.literal"] = colors["@markup.raw"]
-	colors["@text.uri"] = colors["@markup.link.uri"]
+	colors["@text.uri"] = colors["@markup.link.url"]
 	colors["@text.math"] = colors["@markup.math"]
 	colors["@text.environment"] = colors["@markup.environment"]
 	colors["@text.environment.name"] = colors["@markup.environment.name"]
+
+	colors["@text.title"] = colors["@markup.heading"]
+	colors["@text.literal"] = colors["@markup.raw"]
 	colors["@text.reference"] = colors["@markup.reference"]
 
-	colors["@text.todo"] = colors["@markup.todo"]
-	colors["@text.todo.checked"] = colors["@markup.todo.checked"]
-	colors["@text.todo.unchecked"] = colors["@markup.todo.unchecked"]
-	colors["@text.note"] = colors["@markup.note"]
-	colors["@text.warning"] = colors["@markup.warning"]
-	colors["@text.danger"] = colors["@markup.danger"]
+	colors["@text.todo.checked"] = colors["@markup.list.checked"]
+	colors["@text.todo.unchecked"] = colors["@markup.list.unchecked"]
 
-	colors["@text.diff.add"] = colors["@markup.diff.add"]
-	colors["@text.diff.delete"] = colors["@markup.diff.delete"]
+	-- @text.todo is now for todo comments, not todo notes like in markdown
+	colors["@text.todo"] = colors["comment.warning"]
+	colors["@text.warning"] = colors["comment.warning"]
+	colors["@text.note"] = colors["comment.note"]
+	colors["@text.danger"] = colors["comment.error"]
+
+	-- @text.uri is now
+	-- @markup.link.url in markup links
+	-- @string.special.url outside of markup
+	colors["text.uri"] = colors["@markup.link.uri"]
+
+	colors["@method"] = colors["@function.method"]
+	colors["@method.call"] = colors["@function.method.call"]
+
+	colors["@text.diff.add"] = colors["@diff.plus"]
+	colors["@text.diff.delete"] = colors["@diff.minus"]
+
+	colors["@preproc"] = colors["@keyword.directive"]
+	colors["@storageclass"] = colors["@keyword.storage"]
 
 	colors["@symbol.ruby"] = colors["@string.special.symbol.ruby"]
+
+	colors["@variable.member.yaml"] = colors["@field.yaml"]
+
+	colors["@text.title.1.markdown"] = colors["@markup.heading.1.markdown"]
+	colors["@text.title.2.markdown"] = colors["@markup.heading.2.markdown"]
+	colors["@text.title.3.markdown"] = colors["@markup.heading.3.markdown"]
+	colors["@text.title.4.markdown"] = colors["@markup.heading.4.markdown"]
+	colors["@text.title.5.markdown"] = colors["@markup.heading.5.markdown"]
+	colors["@text.title.6.markdown"] = colors["@markup.heading.6.markdown"]
+
+	colors["@method.php"] = colors["@function.method.php"]
+	colors["@method.call.php"] = colors["@function.method.call.php"]
 
 	return colors
 end

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -12,7 +12,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		return {}
 	end
 
-	return { -- Reference: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md
+	local colors = { -- Reference: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md
 
 		-- Misc
 		["@comment"] = { link = "Comment" },
@@ -28,16 +28,18 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Literals
 		["@string"] = { link = "String" }, -- For strings.
-		["@string.regex"] = { fg = C.peach, style = O.styles.strings or {} }, -- For regexes.
+		["@string.regexp"] = { fg = C.peach, style = O.styles.strings or {} }, -- For regexes.
 		["@string.escape"] = { fg = C.pink, style = O.styles.strings or {} }, -- For escape characters within a string.
 		["@string.special"] = { link = "Special" }, -- other special strings (e.g. dates)
+		["@string.special.symbol"] = { fg = C.flamingo },
 
 		["@character"] = { link = "Character" }, -- character literals
 		["@character.special"] = { link = "SpecialChar" }, -- special characters (e.g. wildcards)
 
 		["@boolean"] = { link = "Boolean" }, -- For booleans.
+
 		["@number"] = { link = "Number" }, -- For all numbers
-		["@float"] = { link = "Float" }, -- For floats.
+		["@number.float"] = { link = "Float" }, -- For floats.
 
 		-- Functions
 		["@function"] = { link = "Function" }, -- For function (calls and definitions).
@@ -48,7 +50,6 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@method.call"] = { link = "Function" }, -- For method calls.
 
 		["@constructor"] = { fg = C.sapphire }, -- For constructor calls and definitions: = { } in Lua, and Java constructors.
-		["@parameter"] = { fg = C.maroon, style = O.styles.variables or {} }, -- For parameters of a function.
 
 		-- Keywords
 		["@keyword"] = { link = "Keyword" }, -- For keywords that don't fall in previous categories.
@@ -80,37 +81,37 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		["@variable"] = { fg = C.text, style = O.styles.variables or {} }, -- Any variable name that does not have another highlight.
 		["@variable.builtin"] = { fg = C.red, style = O.styles.properties or {} }, -- Variable names that are defined by the languages, like this or self.
+		["@variable.parameter"] = { fg = C.maroon, style = O.styles.variables or {} }, -- For parameters of a function.
 
 		["@constant"] = { link = "Constant" }, -- For constants
 		["@constant.builtin"] = { fg = C.peach, style = O.styles.keywords or {} }, -- For constant that are built in the language: nil in Lua.
 		["@constant.macro"] = { link = "Macro" }, -- For constants that are defined by macros: NULL in C.
 
-		["@namespace"] = { fg = C.lavender, style = { "italic" } }, -- For identifiers referring to modules and namespaces.
-		["@symbol"] = { fg = C.flamingo },
+		["@module"] = { fg = C.lavender, style = { "italic" } }, -- For identifiers referring to modules and namespaces.
 
 		-- Text
-		["@text"] = { fg = C.text }, -- For strings considerated text in a markup language.
-		["@text.strong"] = { fg = C.maroon, style = { "bold" } }, -- bold
-		["@text.emphasis"] = { fg = C.maroon, style = { "italic" } }, -- italic
-		["@text.underline"] = { link = "Underline" }, -- underlined text
-		["@text.strike"] = { fg = C.text, style = { "strikethrough" } }, -- strikethrough text
-		["@text.title"] = { fg = C.blue, style = { "bold" } }, -- titles like: # Example
-		["@text.literal"] = { fg = C.teal }, -- used for inline code in markdown and for doc in python (""")
-		["@text.uri"] = { fg = C.rosewater, style = { "italic", "underline" } }, -- urls, links and emails
-		["@text.math"] = { fg = C.blue }, -- math environments (e.g. `$ ... $` in LaTeX)
-		["@text.environment"] = { fg = C.pink }, -- text environments of markup languages
-		["@text.environment.name"] = { fg = C.blue }, -- text indicating the type of an environment
-		["@text.reference"] = { link = "Tag" }, -- text references, footnotes, citations, etc.
+		["@markup"] = { fg = C.text }, -- For strings considerated text in a markup language.
+		["@markup.strong"] = { fg = C.maroon, style = { "bold" } }, -- bold
+		["@markup.emphasis"] = { fg = C.maroon, style = { "italic" } }, -- italic
+		["@markup.underline"] = { link = "Underline" }, -- underlined text
+		["@markup.strike"] = { fg = C.text, style = { "strikethrough" } }, -- strikethrough text
+		["@markup.headline"] = { fg = C.blue, style = { "bold" } }, -- titles like: # Example
+		["@markup.raw"] = { fg = C.teal }, -- used for inline code in markdown and for doc in python (""")
+		["@markup.link.uri"] = { fg = C.rosewater, style = { "italic", "underline" } }, -- urls, links and emails
+		["@markup.math"] = { fg = C.blue }, -- math environments (e.g. `$ ... $` in LaTeX)
+		["@markup.environment"] = { fg = C.pink }, -- text environments of markup languages
+		["@markup.environment.name"] = { fg = C.blue }, -- text indicating the type of an environment
+		["@markup.reference"] = { link = "Tag" }, -- text references, footnotes, citations, etc.
 
-		["@text.todo"] = { fg = C.base, bg = C.yellow }, -- todo notes
-		["@text.todo.checked"] = { fg = C.green }, -- todo notes
-		["@text.todo.unchecked"] = { fg = C.overlay1 }, -- todo notes
-		["@text.note"] = { fg = C.base, bg = C.blue },
-		["@text.warning"] = { fg = C.base, bg = C.yellow },
-		["@text.danger"] = { fg = C.base, bg = C.red },
+		["@markup.todo"] = { fg = C.base, bg = C.yellow }, -- todo notes
+		["@markup.todo.checked"] = { fg = C.green }, -- todo notes
+		["@markup.todo.unchecked"] = { fg = C.overlay1 }, -- todo notes
+		["@markup.note"] = { fg = C.base, bg = C.blue },
+		["@markup.warning"] = { fg = C.base, bg = C.yellow },
+		["@markup.danger"] = { fg = C.base, bg = C.red },
 
-		["@text.diff.add"] = { link = "diffAdded" }, -- added text (for diff files)
-		["@text.diff.delete"] = { link = "diffRemoved" }, -- deleted text (for diff files)
+		["@markup.diff.add"] = { link = "diffAdded" }, -- added text (for diff files)
+		["@markup.diff.delete"] = { link = "diffRemoved" }, -- deleted text (for diff files)
 
 		-- Tags
 		["@tag"] = { fg = C.mauve }, -- Tags like html tag names.
@@ -162,7 +163,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@field.yaml"] = { fg = C.blue }, -- For fields.
 
 		-- Ruby
-		["@symbol.ruby"] = { fg = C.flamingo },
+		["@string.special.symbol.ruby"] = { fg = C.flamingo },
 
 		-- PHP
 		["@method.php"] = { link = "Function" },
@@ -177,6 +178,40 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		gitcommitSummary = { fg = C.rosewater, style = { "italic" } },
 		zshKSHFunction = { link = "Function" },
 	}
+
+	-- Legacy highlights
+	colors["@parameter"] = colors["@variable.parameter"]
+	colors["@namespace"] = colors["@module"]
+	colors["@float"] = colors["number.float"]
+	colors["@symbol"] = colors["@string.special.symbol"]
+	colors["@string.regex"] = colors["@string.regexp"]
+
+	colors["@text"] = colors["@markup"]
+	colors["@text.strong"] = colors["@markup.strong"]
+	colors["@text.emphasis"] = colors["@markup.emphasis"]
+	colors["@text.underline"] = colors["@markup.underline"]
+	colors["@text.strike"] = colors["@markup.strike"]
+	colors["@text.title"] = colors["@markup.headline"]
+	colors["@text.literal"] = colors["@markup.raw"]
+	colors["@text.uri"] = colors["@markup.link.uri"]
+	colors["@text.math"] = colors["@markup.math"]
+	colors["@text.environment"] = colors["@markup.environment"]
+	colors["@text.environment.name"] = colors["@markup.environment.name"]
+	colors["@text.reference"] = colors["@markup.reference"]
+
+	colors["@text.todo"] = colors["@markup.todo"]
+	colors["@text.todo.checked"] = colors["@markup.todo.checked"]
+	colors["@text.todo.unchecked"] = colors["@markup.todo.unchecked"]
+	colors["@text.note"] = colors["@markup.note"]
+	colors["@text.warning"] = colors["@markup.warning"]
+	colors["@text.danger"] = colors["@markup.danger"]
+
+	colors["@text.diff.add"] = colors["@markup.diff.add"]
+	colors["@text.diff.delete"] = colors["@markup.diff.delete"]
+
+	colors["@symbol.ruby"] = colors["@string.special.symbol.ruby"]
+
+	return colors
 end
 
 return M

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -16,7 +16,6 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Misc
 		["@error"] = { link = "Error" },
-		["@define"] = { link = "Define" }, -- preprocessor definition directives
 		["@operator"] = { link = "Operator" }, -- For any operator: +, but also -> and * in C.
 
 		-- Comment
@@ -63,15 +62,16 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@keyword.return"] = { fg = C.mauve, style = O.styles.keywords or {} },
 		["@keyword.storage"] = { link = "StorageClass" }, -- visibility/life-time/etc. modifiers (e.g. `static`)
 		["@keyword.directive"] = { link = "PreProc" }, -- various preprocessor directives & shebangs
+		["@keyword.directive.define"] = { link = "Define" }, -- preprocessor definition directives
+		["@keyword.repeat"] = { link = "Repeat" }, -- For keywords related to loops.
+		["@keyword.exception"] = { link = "Exception" }, -- For exception related keywords.
+		["@keyword.import"] = { link = "Include" }, -- For includes: #include in C, use or extern crate in Rust, or require in Lua.
+		["@keyword.conditional"] = { link = "Conditional" }, -- For keywords related to conditionnals.
 		-- JS & derivative
 		["@keyword.export"] = { fg = C.sky, style = O.styles.keywords },
 
-		["@conditional"] = { link = "Conditional" }, -- For keywords related to conditionnals.
-		["@repeat"] = { link = "Repeat" }, -- For keywords related to loops.
 		-- @debug            ; keywords related to debugging
 		["@label"] = { link = "Label" }, -- For labels: label: in C and :label: in Lua.
-		["@include"] = { link = "Include" }, -- For includes: #include in C, use or extern crate in Rust, or require in Lua.
-		["@exception"] = { link = "Exception" }, -- For exception related keywords.
 
 		-- Types
 		["@type"] = { link = "Type" }, -- For types.
@@ -98,16 +98,16 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		-- Text
 		["@markup"] = { fg = C.text }, -- For strings considerated text in a markup language.
 		["@markup.strong"] = { fg = C.maroon, style = { "bold" } }, -- bold
-		["@markup.emphasis"] = { fg = C.maroon, style = { "italic" } }, -- italic
+		["@markup.italic"] = { fg = C.maroon, style = { "italic" } }, -- italic
 		["@markup.underline"] = { link = "Underline" }, -- underlined text
-		["@markup.strike"] = { fg = C.text, style = { "strikethrough" } }, -- strikethrough text
+		["@markup.strikethrough"] = { fg = C.text, style = { "strikethrough" } }, -- strikethrough text
 		["@markup.heading"] = { fg = C.blue, style = { "bold" } }, -- titles like: # Example
 		["@markup.raw"] = { fg = C.teal }, -- used for inline code in markdown and for doc in python (""")
 		["@markup.link.url"] = { fg = C.rosewater, style = { "italic", "underline" } }, -- urls, links and emails
 		["@markup.math"] = { fg = C.blue }, -- math environments (e.g. `$ ... $` in LaTeX)
 		["@markup.environment"] = { fg = C.pink }, -- text environments of markup languages
 		["@markup.environment.name"] = { fg = C.blue }, -- text indicating the type of an environment
-		["@markup.reference"] = { link = "Tag" }, -- text references, footnotes, citations, etc.
+		["@markup.link"] = { link = "Tag" }, -- text references, footnotes, citations, etc.
 
 		["@markup.list"] = { link = "Special" },
 		["@markup.list.checked"] = { fg = C.green }, -- todo notes
@@ -194,9 +194,9 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 	colors["@text"] = colors["@markup"]
 	colors["@text.strong"] = colors["@markup.strong"]
-	colors["@text.emphasis"] = colors["@markup.emphasis"]
+	colors["@text.emphasis"] = colors["@markup.italic"]
 	colors["@text.underline"] = colors["@markup.underline"]
-	colors["@text.strike"] = colors["@markup.strike"]
+	colors["@text.strike"] = colors["@markup.strikethrough"]
 	colors["@text.uri"] = colors["@markup.link.url"]
 	colors["@text.math"] = colors["@markup.math"]
 	colors["@text.environment"] = colors["@markup.environment"]
@@ -204,7 +204,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 	colors["@text.title"] = colors["@markup.heading"]
 	colors["@text.literal"] = colors["@markup.raw"]
-	colors["@text.reference"] = colors["@markup.reference"]
+	colors["@text.reference"] = colors["@markup.link"]
 
 	colors["@text.todo.checked"] = colors["@markup.list.checked"]
 	colors["@text.todo.unchecked"] = colors["@markup.list.unchecked"]
@@ -226,8 +226,13 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 	colors["@text.diff.add"] = colors["@diff.plus"]
 	colors["@text.diff.delete"] = colors["@diff.minus"]
 
+	colors["@define"] = colors["@keyword.directive.define"]
 	colors["@preproc"] = colors["@keyword.directive"]
 	colors["@storageclass"] = colors["@keyword.storage"]
+	colors["@conditional"] = colors["@keyword.conditional"]
+	colors["exception"] = colors["@keyword.exception"]
+	colors["@include"] = colors["@keyword.import"]
+	colors["@repeat"] = colors["@keyword.repeat"]
 
 	colors["@symbol.ruby"] = colors["@string.special.symbol.ruby"]
 


### PR DESCRIPTION
nvim-treesitter may be updated soon, still in discussion but it is planned, see https://github.com/nvim-treesitter/nvim-treesitter/issues/4799#issuecomment-1860154411. The purpose is to follow the treesitter common core to share queries, so some captures will be redefined.

I created this PR to follow upstream changes to avoid highlights break by the breaking change.

There are some highlights defined in treesitter common core but not mentioned in nvim-treesitter

- `@carriage-return`
- `@comment.documentation`
- `@embedded`
- `@escape`
- `@markup.link`
- `@markup.quote`
- `@property.builtin`
- `@variable.member`

And not sure all helix captures will be applied. This PR only follow the common core, need to continue to follow the implementation.
