### PR TITLE
feat: use a more distinguishable color for todos

### DIFF
--- a/lua/catppuccin/groups/integrations/NormalNvim.lua
+++ b/lua/catppuccin/groups/integrations/NormalNvim.lua
@@ -3,7 +3,7 @@ local M = {}
 function M.get()
 	return {
 		MarkdownTask = { fg = C.teal, style = { "bold" } },
-		MarkdownTodo = { fg = C.yellow, style = { "bold" } },
+		MarkdownTodo = { fg = C.flamingo, style = { "bold" } },
 		MarkdownNote = { fg = C.red, style = { "bold" } },
 		MarkdownSee = { fg = C.blue, style = { "bold" } },
 		MarkdownCheck = { fg = C.green, style = { "bold" } },

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -213,11 +213,13 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 	colors["@text.todo.checked"] = colors["@markup.list.checked"]
 	colors["@text.todo.unchecked"] = colors["@markup.list.unchecked"]
 
+	colors["@comment.note"] = colors["@comment.hint"]
+
 	-- @text.todo is now for todo comments, not todo notes like in markdown
-	colors["@text.todo"] = colors["comment.todo"]
-	colors["@text.warning"] = colors["comment.warning"]
-	colors["@text.note"] = colors["comment.note"]
-	colors["@text.danger"] = colors["comment.error"]
+	colors["@text.todo"] = colors["@comment.todo"]
+	colors["@text.warning"] = colors["@comment.warning"]
+	colors["@text.note"] = colors["@comment.note"]
+	colors["@text.danger"] = colors["@comment.error"]
 
 	-- @text.uri is now
 	-- @markup.link.url in markup links
@@ -251,8 +253,6 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 	colors["@method.php"] = colors["@function.method.php"]
 	colors["@method.call.php"] = colors["@function.method.call.php"]
-
-	colors["@comment.note"] = colors["@comment.hint"]
 
 	return colors
 end

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -90,6 +90,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@comment.error"] = { fg = C.base, bg = C.red },
 		["@comment.warning"] = { fg = C.base, bg = C.yellow },
 		["@comment.note"] = { fg = C.base, bg = C.blue },
+		["@comment.todo"] = { fg = C.base, bg = C.flamingo },
 
 		-- Markup
 		["@markup"] = { fg = C.text }, -- For strings considerated text in a markup language.
@@ -213,7 +214,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 	colors["@text.todo.unchecked"] = colors["@markup.list.unchecked"]
 
 	-- @text.todo is now for todo comments, not todo notes like in markdown
-	colors["@text.todo"] = colors["comment.warning"]
+	colors["@text.todo"] = colors["comment.todo"]
 	colors["@text.warning"] = colors["comment.warning"]
 	colors["@text.note"] = colors["comment.note"]
 	colors["@text.danger"] = colors["comment.error"]

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -89,7 +89,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		["@comment.error"] = { fg = C.base, bg = C.red },
 		["@comment.warning"] = { fg = C.base, bg = C.yellow },
-		["@comment.note"] = { fg = C.base, bg = C.blue },
+		["@comment.hint"] = { fg = C.base, bg = C.blue },
 		["@comment.todo"] = { fg = C.base, bg = C.flamingo },
 
 		-- Markup
@@ -251,6 +251,8 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 	colors["@method.php"] = colors["@function.method.php"]
 	colors["@method.call.php"] = colors["@function.method.call.php"]
+
+	colors["@comment.note"] = colors["@comment.hint"]
 
 	return colors
 end

--- a/lua/catppuccin/groups/syntax.lua
+++ b/lua/catppuccin/groups/syntax.lua
@@ -43,7 +43,7 @@ function M.get()
 		-- Ignore = { }, -- (preferred) left blank, hidden  |hl-Ignore|
 
 		Error = { fg = C.red }, -- (preferred) any erroneous construct
-		Todo = { bg = C.yellow, fg = C.base, style = { "bold" } }, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
+		Todo = { bg = C.flamingo, fg = C.base, style = { "bold" } }, -- (preferred) anything that needs extra attention; mostly the keywords TODO FIXME and XXX
 		qfLineNr = { fg = C.yellow },
 		qfFileName = { fg = C.blue },
 		htmlH1 = { fg = C.pink, style = { "bold" } },


### PR DESCRIPTION
Previously, there was no distinction between the colors of `@comment.todo` and `@comment.warn.` The reason is that the color of the warning and the color of the todo are both yellow. I suggest changing the color of the todo to a slightly different color.

![image](https://github.com/catppuccin/nvim/assets/61115159/1f7ba5c3-41c7-4cec-b9c3-359918e44ff3)
