### PR TITLE
fix: wrong color shown when using color_overrides

### DIFF
--- a/lua/catppuccin/palettes/init.lua
+++ b/lua/catppuccin/palettes/init.lua
@@ -7,9 +7,12 @@ function M.get_palette(flavour)
 	local ans = vim.tbl_deep_extend("keep", O.color_overrides.all or {}, O.color_overrides[flvr] or {}, palette or {})
 	if O.kitty then -- https://github.com/kovidgoyal/kitty/issues/2917
 		for accent, hex in pairs(ans) do
-			local int = hex:gsub("#", "0x")
-			int = tonumber(int)
-			ans[accent] = string.format("#%.6x", int == 16777215 and int - 1 or int + 1)
+			local red_green_string = hex:sub(1, 5)
+			local blue_value = tonumber(hex:sub(6, 7), 16)
+
+			-- Slightly increase or decrease brightness of the blue channel
+			blue_value = blue_value == 255 and blue_value - 1 or blue_value + 1
+			ans[accent] = string.format("%s%.2x", red_green_string, blue_value)
 		end
 	end
 	return ans


### PR DESCRIPTION
Fix for #657 (Wrong color shown when using color_overrides in Kitty).

Rewrote this section of code to increment or decrement just the blue channel instead of treating color as a single number.