### PR TITLE
feat(treesitter): add styles.miscs to disable hardcoded italics

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ require("catppuccin").setup({
         properties = {},
         types = {},
         operators = {},
+        -- miscs = {}, -- Uncomment to turn off hard-coded styles
     },
     color_overrides = {},
     custom_highlights = {},

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -99,6 +99,7 @@ options and settings.
             properties = {},
             types = {},
             operators = {},
+            -- miscs = {}, -- Uncomment to turn off hard-coded styles
         },
         color_overrides = {},
         custom_highlights = {},

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -23,7 +23,9 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@constant.builtin"] = { fg = C.peach, style = O.styles.keywords or {} }, -- For constant that are built in the language: nil in Lua.
 		["@constant.macro"] = { link = "Macro" }, -- For constants that are defined by macros: NULL in C.
 
-		["@module"] = { fg = C.lavender, style = { "italic" } }, -- For identifiers referring to modules and namespaces.
+		-- This is difficult to avoid hardcoding, as there is no user option for this (yet).
+		-- For now, binding to `conditionals` because it is italic by default.
+		["@module"] = { fg = C.lavender, style = O.styles.conditionals or { "italic" } }, -- For identifiers referring to modules and namespaces.
 		["@label"] = { link = "Label" }, -- For labels: label: in C and :label: in Lua.
 
 		-- Literals
@@ -121,7 +123,11 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Tags
 		["@tag"] = { fg = C.mauve }, -- Tags like html tag names.
-		["@tag.attribute"] = { fg = C.teal, style = { "italic" } }, -- Tags like html tag names.
+		-- God I have no idea what to label this as… Well, for now, I’ll just
+		-- label everything as `conditionals`, to keep them italic by default.
+		-- If someone wants to, they can create more user options and solve
+		-- the problem that way. This is really just a cheap quick fix.
+		["@tag.attribute"] = { fg = C.teal, style = O.styles.conditionals or { "italic" } }, -- Tags like html tag names.
 		["@tag.delimiter"] = { fg = C.sky }, -- Tag delimiter like < > /
 
 		-- Misc
@@ -129,7 +135,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Language specific:
 		-- bash
-		["@function.builtin.bash"] = { fg = C.red, style = { "italic" } },
+		["@function.builtin.bash"] = { fg = C.red, style = O.styles.conditionals or { "italic" } },
 
 		-- markdown
 		["@markup.heading.1.markdown"] = { link = "rainbow1" },
@@ -166,7 +172,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- TSX (Typescript React)
 		["@constructor.tsx"] = { fg = C.lavender },
-		["@tag.attribute.tsx"] = { fg = C.mauve, style = { "italic" } },
+		["@tag.attribute.tsx"] = { fg = C.mauve, style = O.styles.conditionals or { "italic" } },
 
 		-- yaml
 		["@variable.member.yaml"] = { fg = C.blue }, -- For fields.
@@ -179,12 +185,13 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@function.method.call.php"] = { link = "Function" },
 
 		-- C/CPP
+		-- THIS IS WEIRD, why are they hardcoded to not have styles???
 		["@type.builtin.c"] = { fg = C.yellow, style = {} },
 		["@property.cpp"] = { fg = C.text },
 		["@type.builtin.cpp"] = { fg = C.yellow, style = {} },
 
 		-- Misc
-		gitcommitSummary = { fg = C.rosewater, style = { "italic" } },
+		gitcommitSummary = { fg = C.rosewater, style = O.styles.comments or { "italic" } },
 		zshKSHFunction = { link = "Function" },
 	}
 

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -23,9 +23,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@constant.builtin"] = { fg = C.peach, style = O.styles.keywords or {} }, -- For constant that are built in the language: nil in Lua.
 		["@constant.macro"] = { link = "Macro" }, -- For constants that are defined by macros: NULL in C.
 
-		-- This is difficult to avoid hardcoding, as there is no user option for this (yet).
-		-- For now, binding to `conditionals` because it is italic by default.
-		["@module"] = { fg = C.lavender, style = O.styles.conditionals or { "italic" } }, -- For identifiers referring to modules and namespaces.
+		["@module"] = { fg = C.lavender, style = O.styles.miscs or { "italic" } }, -- For identifiers referring to modules and namespaces.
 		["@label"] = { link = "Label" }, -- For labels: label: in C and :label: in Lua.
 
 		-- Literals
@@ -123,11 +121,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Tags
 		["@tag"] = { fg = C.mauve }, -- Tags like html tag names.
-		-- God I have no idea what to label this as… Well, for now, I’ll just
-		-- label everything as `conditionals`, to keep them italic by default.
-		-- If someone wants to, they can create more user options and solve
-		-- the problem that way. This is really just a cheap quick fix.
-		["@tag.attribute"] = { fg = C.teal, style = O.styles.conditionals or { "italic" } }, -- Tags like html tag names.
+		["@tag.attribute"] = { fg = C.teal, style = O.styles.miscs or { "italic" } }, -- Tags like html tag names.
 		["@tag.delimiter"] = { fg = C.sky }, -- Tag delimiter like < > /
 
 		-- Misc
@@ -135,7 +129,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Language specific:
 		-- bash
-		["@function.builtin.bash"] = { fg = C.red, style = O.styles.conditionals or { "italic" } },
+		["@function.builtin.bash"] = { fg = C.red, style = O.styles.miscs or { "italic" } },
 
 		-- markdown
 		["@markup.heading.1.markdown"] = { link = "rainbow1" },
@@ -172,8 +166,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- TSX (Typescript React)
 		["@constructor.tsx"] = { fg = C.lavender },
-
-		["@tag.attribute.tsx"] = { fg = C.teal, style = O.styles.conditionals or { "italic" } },
+		["@tag.attribute.tsx"] = { fg = C.teal, style = O.styles.miscs or { "italic" } },
 
 		-- yaml
 		["@variable.member.yaml"] = { fg = C.blue }, -- For fields.
@@ -186,13 +179,12 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@function.method.call.php"] = { link = "Function" },
 
 		-- C/CPP
-		-- THIS IS WEIRD, why are they hardcoded to not have styles???
 		["@type.builtin.c"] = { fg = C.yellow, style = {} },
 		["@property.cpp"] = { fg = C.text },
 		["@type.builtin.cpp"] = { fg = C.yellow, style = {} },
 
 		-- Misc
-		gitcommitSummary = { fg = C.rosewater, style = O.styles.comments or { "italic" } },
+		gitcommitSummary = { fg = C.rosewater, style = O.styles.miscs or { "italic" } },
 		zshKSHFunction = { link = "Function" },
 	}
 

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -81,6 +81,8 @@
 ---@field types CtpHighlightArgs[]?
 -- Change the style of operators.
 ---@field operators CtpHighlightArgs[]?
+-- Change the style of miscs.
+---@field miscs CtpHighlightArgs[]?
 
 ---@class CtpNativeLspStyles
 -- Change the style of LSP errors.


### PR DESCRIPTION
Set everything to `O.styles.conditionals or { "italic" }`, so, by default, the various settings are still italic. In other words, this is not a breaking change.

🎉 First off, thanks for taking the time to contribute! 🎉

Here are some guidelines:
- Format code using [stylua](https://github.com/johnnymorganz/stylua).
- New plugin integration should be added in alphabetical order:
  - to the [README](https://github.com/catppuccin/nvim#integrations) (vimdoc is auto-generated).
  - to [types.lua](https://github.com/catppuccin/nvim/blob/main/lua/catppuccin/types.lua)
- Create a topic branch on your fork for your specific PR.
- Use [conventionalcommits.org's](https://www.conventionalcommits.org/en/v1.0.0/)
  rules for explicit and meaningful commit messages.
- If it's your first time contributing to a project, then read
  [About pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
  on Github's docs.

Here are some tips:
- Use `vim.g.catppuccin_debug = true` to get live config re-loading
