### PR TITLE
fix: ensure consistency between JSX and HTML markup

### DIFF
--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -166,7 +166,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- TSX (Typescript React)
 		["@constructor.tsx"] = { fg = C.lavender },
-		["@tag.attribute.tsx"] = { fg = C.mauve, style = { "italic" } },
+		["@tag.attribute.tsx"] = { fg = C.teal, style = { "italic" } },
 
 		-- yaml
 		["@variable.member.yaml"] = { fg = C.blue }, -- For fields.


### PR DESCRIPTION
## Ensure consistency in color scheme between JSX elements and HTML markup.

### Before
![before](https://github.com/catppuccin/nvim/assets/96499344/ac09921d-e184-4880-93dc-26c80f9d2a5f)
### After
![after](https://github.com/catppuccin/nvim/assets/96499344/da6c85a5-5f8a-408b-b92c-dc5685550545)

### HTML reference
![image](https://github.com/catppuccin/nvim/assets/96499344/801b8a48-8911-4dd0-a284-4742b231752e)
