### PR TITLE
feat: set `@comment.warning` that does not affect readability in gitc…

### DIFF
--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -183,6 +183,9 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@property.cpp"] = { fg = C.text },
 		["@type.builtin.cpp"] = { fg = C.yellow, style = {} },
 
+		-- gitcommit
+		["@comment.warning.gitcommit"] = { fg = C.yellow },
+
 		-- Misc
 		gitcommitSummary = { fg = C.rosewater, style = O.styles.miscs or { "italic" } },
 		zshKSHFunction = { link = "Function" },


### PR DESCRIPTION
Previous, with general `@comment.warning`:
![image](https://github.com/catppuccin/nvim/assets/61115159/0627d98e-d63f-42a2-bb8e-4790bfb4b879)

After:
![image](https://github.com/catppuccin/nvim/assets/61115159/b67e8941-c4d4-4d34-bcbc-47a50e4a37ad)
