### PR TITLE
feat: allow terminal color overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,48 @@ require("catppuccin").setup {
 > [!Note]
 > For more information check out our [style-guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md)
 
+## Overwriting terminal colors
+
+If `term_colors` has been set to `true`, the terminal colors used can be overwritten using `terminal_overrides`:
+
+```lua
+    require("catppuccin").setup {
+        terminal_overrides = {
+            all = function(C)
+                return {
+                  terminal_color_0 = C.overlay0,
+                  terminal_color_8 = C.overlay1,
+
+                  terminal_color_1 = C.red,
+                  terminal_color_9 = C.red,
+
+                  terminal_color_2 = C.green,
+                  terminal_color_10 = C.green,
+
+                  terminal_color_3 = C.mauve,
+                  terminal_color_11 = C.mauve,
+
+                  terminal_color_4 = C.blue,
+                  terminal_color_12 = C.blue,
+
+                  terminal_color_5 = C.pink,
+                  terminal_color_13 = C.pink,
+
+                  terminal_color_6 = C.lavender,
+                  terminal_color_14 = C.lavender,
+
+                  terminal_color_7 = C.text,
+                  terminal_color_15 = C.subtext1,
+                }
+            end,
+            mocha = {
+                terminal_color_5 = "#ffff00",
+                terminal_color_13 = "#ffff00",
+            },
+        },
+    }
+```
+
 ## Overwriting highlight groups
 
 Global highlight groups can be overwritten in the setting, for example:

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -166,6 +166,49 @@ https://github.com/catppuccin/nvim/discussions/323 for inspirations:
   [!Note] For more information check out our style-guide
   <https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md>
 
+OVERWRITING TERMINAL COLORS  *catppuccin-customize-highlights-overwriting-terminal-colors*
+
+If `term_colors` has been set to `true`, the terminal colors used can be overwritten 
+using `terminal_overrides`:
+
+>lua
+    require("catppuccin").setup {
+        terminal_overrides = {
+            all = function(C)
+                return {
+                  terminal_color_0 = C.overlay0,
+                  terminal_color_8 = C.overlay1,
+
+                  terminal_color_1 = C.red,
+                  terminal_color_9 = C.red,
+
+                  terminal_color_2 = C.green,
+                  terminal_color_10 = C.green,
+
+                  terminal_color_3 = C.mauve,
+                  terminal_color_11 = C.mauve,
+
+                  terminal_color_4 = C.blue,
+                  terminal_color_12 = C.blue,
+
+                  terminal_color_5 = C.pink,
+                  terminal_color_13 = C.pink,
+
+                  terminal_color_6 = C.lavender,
+                  terminal_color_14 = C.lavender,
+
+                  terminal_color_7 = C.text,
+                  terminal_color_15 = C.subtext1,
+                }
+            end,
+            mocha = {
+                terminal_color_5 = "#ffff00",
+                terminal_color_13 = "#ffff00",
+            },
+        },
+    }
+<
+
 OVERWRITING HIGHLIGHT GROUPS*catppuccin-customize-highlights-overwriting-highlight-groups*
 
 Global highlight groups can be overwritten in the setting, for example:

--- a/lua/catppuccin/lib/mapper.lua
+++ b/lua/catppuccin/lib/mapper.lua
@@ -56,6 +56,16 @@ function M.apply(flavour)
 
 	theme.integrations = final_integrations -- plugins
 	theme.terminal = require("catppuccin.groups.terminal").get() -- terminal colors
+
+	local user_terminal = O.terminal_overrides
+	if type(user_terminal[flavour]) == "function" then user_terminal[flavour] = user_terminal[flavour](C) end
+	theme.terminal = vim.tbl_deep_extend(
+		"keep",
+		user_terminal[flavour] or {},
+		type(user_terminal.all) == "function" and user_terminal.all(C) or user_terminal.all or {},
+		theme.terminal
+	)
+
 	local user_highlights = O.highlight_overrides
 	if type(user_highlights[flavour]) == "function" then user_highlights[flavour] = user_highlights[flavour](C) end
 	theme.custom_highlights = vim.tbl_deep_extend(

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -35,6 +35,8 @@
 ---@field integrations CtpIntegrations?
 -- Catppuccin colors can be overwritten here.
 ---@field color_overrides CtpColors | CtpFlavors<CtpColors<string>> | nil
+-- Catppuccin terminal colors can be overwritten here.
+---@field terminal_overrides CtpColors | CtpFlavors<CtpColors<string>> | nil
 -- Catppuccin highlights can be overwritten here.
 ---@field highlight_overrides CtpHighlightOverrides?
 -- Global highlight overrides.


### PR DESCRIPTION
This allows users that set `term_colors = true` to override the colors that catppuccin assigns. For example:

```lua
    term_colors = true,
    terminal_overrides = {
      all = function(C)
        return {
          terminal_color_3 = C.peach,
          terminal_color_11 = C.peach,
        }
      end,
      mocha = {
        terminal_color_5 = "#ffff00",
      },
    },
```