### PR TITLE
feat(feline): fix feline integration

### DIFF
--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -26,7 +26,7 @@ local assets = {
 
 local sett = {
 	text = C.mantle,
-	bkg = C.mantle,
+	bkg = C.surface0,
 	diffs = C.mauve,
 	extras = C.overlay1,
 	curr_file = C.maroon,
@@ -71,7 +71,11 @@ function M.setup(opts)
 		opts.sett = opts.sett or {}
 		opts.mode_colors = opts.mode_colors or {}
 	else
-		opts = {}
+		opts = {
+			assets = {},
+			sett = {},
+			mode_colors = {},
+		}
 	end
 	assets = vim.tbl_deep_extend("force", assets, opts.assets)
 	sett = vim.tbl_deep_extend("force", sett, opts.sett)


### PR DESCRIPTION

This PR is intended to fix the feline integration by:
- changing the background color from mantle to surface0 which is the actual color used in the pictures
- enable the user to use the setup function without any parameter as described in the documentation

Visual changes:
Old:
<img width="1301" alt="image" src="https://github.com/catppuccin/nvim/assets/3298487/e748a430-3e60-48ef-a47b-9d4623f4f01e">

New:
<img width="1304" alt="image" src="https://github.com/catppuccin/nvim/assets/3298487/1d9f3ee2-8549-4a4f-8b0e-7b86dcf53813">

Reference:
![](https://user-images.githubusercontent.com/56817415/213471997-34837219-88cc-4db2-baca-e25813a89789.png)
