### PR TITLE
feat(lsp): add highlight for `LspCodeLensSeparator`

### DIFF
--- a/lua/catppuccin/groups/integrations/native_lsp.lua
+++ b/lua/catppuccin/groups/integrations/native_lsp.lua
@@ -85,6 +85,7 @@ function M.get()
 		LspDiagnosticsUnderlineInformation = { style = underlines.information, sp = info }, -- Used to underline "Information" diagnostics
 		LspDiagnosticsUnderlineHint = { style = underlines.hints, sp = hint }, -- Used to underline "Hint" diagnostics
 		LspCodeLens = { fg = C.overlay0 }, -- virtual text of the codelens
+		LspCodeLensSeparator = { fg = C.overlay0 }, -- virtual text of the codelens separators
 		LspInlayHint = {
 			-- fg of `Comment`
 			fg = C.overlay0,

--- a/lua/catppuccin/groups/integrations/native_lsp.lua
+++ b/lua/catppuccin/groups/integrations/native_lsp.lua
@@ -85,7 +85,7 @@ function M.get()
 		LspDiagnosticsUnderlineInformation = { style = underlines.information, sp = info }, -- Used to underline "Information" diagnostics
 		LspDiagnosticsUnderlineHint = { style = underlines.hints, sp = hint }, -- Used to underline "Hint" diagnostics
 		LspCodeLens = { fg = C.overlay0 }, -- virtual text of the codelens
-		LspCodeLensSeparator = { fg = C.overlay0 }, -- virtual text of the codelens separators
+		LspCodeLensSeparator = { link = "LspCodeLens" }, -- virtual text of the codelens separators
 		LspInlayHint = {
 			-- fg of `Comment`
 			fg = C.overlay0,


### PR DESCRIPTION
Otherwise, the color of the separator will be `Normal`, which is ugly because code lenses have a color like `Comment`.
Before:
![image](https://github.com/catppuccin/nvim/assets/61115159/020761f7-2856-4f4a-9e0c-1ca1356828be)
After:
![image](https://github.com/catppuccin/nvim/assets/61115159/e9d0fd2c-ce83-4e0b-ba19-c41e764df5a9)
