### PR TITLE
feat(treesitter): follow upstream captures

### DIFF
--- a/lua/catppuccin/groups/integrations/headlines.lua
+++ b/lua/catppuccin/groups/integrations/headlines.lua
@@ -3,7 +3,7 @@ local M = {}
 function M.get()
 	return {
 		Dash = { fg = C.overlay2, style = { "bold" } },
-		Quote = { link = "@text.strong" },
+		Quote = { link = "@markup.strong" },
 		CodeBlock = { bg = C.mantle },
 		Headline = { link = "Headline1" },
 		Headline1 = { bg = C.surface0, fg = C.red },

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -28,10 +28,12 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Literals
 		["@string"] = { link = "String" }, -- For strings.
+		["@string.documentation"] = { fg = C.teal, style = O.styles.strings or {} }, -- For strings documenting code (e.g. Python docstrings).
 		["@string.regexp"] = { fg = C.peach, style = O.styles.strings or {} }, -- For regexes.
 		["@string.escape"] = { fg = C.pink, style = O.styles.strings or {} }, -- For escape characters within a string.
 		["@string.special"] = { link = "Special" }, -- other special strings (e.g. dates)
-		["@string.special.symbol"] = { fg = C.flamingo },
+		["@string.special.path"] = { link = "Special" }, -- filenames
+		["@string.special.symbol"] = { fg = C.flamingo }, -- symbols or atoms
 		["@string.special.url"] = { fg = C.rosewater, style = { "italic", "underline" } }, -- urls, links and emails
 
 		["@character"] = { link = "Character" }, -- character literals
@@ -45,7 +47,6 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@type"] = { link = "Type" }, -- For types.
 		["@type.builtin"] = { fg = C.yellow, style = O.styles.properties or { "italic" } }, -- For builtin types.
 		["@type.definition"] = { link = "Type" }, -- type definitions (e.g. `typedef` in C)
-		["@type.qualifier"] = { link = "Keyword" }, -- type qualifiers (e.g. `const`)
 
 		["@attribute"] = { link = "Constant" }, -- attribute annotations (e.g. Python decorators)
 		["@property"] = { fg = C.lavender, style = O.styles.properties or {} }, -- Same as TSField.
@@ -64,15 +65,19 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Keywords
 		["@keyword"] = { link = "Keyword" }, -- For keywords that don't fall in previous categories.
+		["@keyword.modifier"] = { link = "Keyword" }, -- For keywords modifying other constructs (e.g. `const`, `static`, `public`)
+		["@keyword.type"] = { link = "Keyword" }, -- For keywords describing composite types (e.g. `struct`, `enum`)
+		["@keyword.coroutine"] = { link = "Keyword" }, -- For keywords related to coroutines (e.g. `go` in Go, `async/await` in Python)
 		["@keyword.function"] = { fg = C.mauve, style = O.styles.keywords or {} }, -- For keywords used to define a function.
-		["@keyword.operator"] = { fg = C.mauve, style = O.styles.operators or {} }, -- For new keyword operator
+		["@keyword.operator"] = { link = "Operator" }, -- For new keyword operator
 		["@keyword.import"] = { link = "Include" }, -- For includes: #include in C, use or extern crate in Rust, or require in Lua.
-		["@keyword.storage"] = { link = "StorageClass" }, -- visibility/life-time/etc. modifiers (e.g. `static`)
 		["@keyword.repeat"] = { link = "Repeat" }, -- For keywords related to loops.
 		["@keyword.return"] = { fg = C.mauve, style = O.styles.keywords or {} },
+		["@keyword.debug"] = { link = "Exception" }, -- For keywords related to debugging
 		["@keyword.exception"] = { link = "Exception" }, -- For exception related keywords.
 
 		["@keyword.conditional"] = { link = "Conditional" }, -- For keywords related to conditionnals.
+		["@keyword.conditional.ternary"] = { link = "Operator" }, -- For ternary operators (e.g. `?` / `:`)
 
 		["@keyword.directive"] = { link = "PreProc" }, -- various preprocessor directives & shebangs
 		["@keyword.directive.define"] = { link = "Define" }, -- preprocessor definition directives
@@ -86,11 +91,13 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Comment
 		["@comment"] = { link = "Comment" },
+		["@comment.documentation"] = { fg = C.teal, style = O.styles.strings or {} }, -- For comments documenting code
 
 		["@comment.error"] = { fg = C.base, bg = C.red },
 		["@comment.warning"] = { fg = C.base, bg = C.yellow },
 		["@comment.hint"] = { fg = C.base, bg = C.blue },
 		["@comment.todo"] = { fg = C.base, bg = C.flamingo },
+		["@comment.note"] = { fg = C.base, bg = C.rosewater },
 
 		-- Markup
 		["@markup"] = { fg = C.text }, -- For strings considerated text in a markup language.
@@ -102,10 +109,12 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@markup.heading"] = { fg = C.blue, style = { "bold" } }, -- titles like: # Example
 
 		["@markup.math"] = { fg = C.blue }, -- math environments (e.g. `$ ... $` in LaTeX)
+		["@markup.quote"] = { fg = C.maroon, style = { "bold" } }, -- block quotes
 		["@markup.environment"] = { fg = C.pink }, -- text environments of markup languages
 		["@markup.environment.name"] = { fg = C.blue }, -- text indicating the type of an environment
 
 		["@markup.link"] = { link = "Tag" }, -- text references, footnotes, citations, etc.
+		["@markup.link.label"] = { link = "Label" }, -- link, reference descriptions
 		["@markup.link.url"] = { fg = C.rosewater, style = { "italic", "underline" } }, -- urls, links and emails
 
 		["@markup.raw"] = { fg = C.teal }, -- used for inline code in markdown and for doc in python (""")
@@ -235,6 +244,8 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 	colors["@text.diff.add"] = colors["@diff.plus"]
 	colors["@text.diff.delete"] = colors["@diff.minus"]
 
+	colors["@type.qualifier"] = colors["@keyword.modifier"]
+	colors["@keyword.storage"] = colors["@keyword.modifier"]
 	colors["@define"] = colors["@keyword.directive.define"]
 	colors["@preproc"] = colors["@keyword.directive"]
 	colors["@storageclass"] = colors["@keyword.storage"]

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -91,7 +91,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Comment
 		["@comment"] = { link = "Comment" },
-		["@comment.documentation"] = { link = "@comment" }, -- For comments documenting code
+		["@comment.documentation"] = { link = "Comment" }, -- For comments documenting code
 
 		["@comment.error"] = { fg = C.base, bg = C.red },
 		["@comment.warning"] = { fg = C.base, bg = C.yellow },

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -91,7 +91,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 
 		-- Comment
 		["@comment"] = { link = "Comment" },
-		["@comment.documentation"] = { fg = C.teal, style = O.styles.strings or {} }, -- For comments documenting code
+		["@comment.documentation"] = { link = "@comment" }, -- For comments documenting code
 
 		["@comment.error"] = { fg = C.base, bg = C.red },
 		["@comment.warning"] = { fg = C.base, bg = C.yellow },


### PR DESCRIPTION
This PR primarily updated highlight groups related to treesitter captures to comply with the latest specification. Deprecated captures were relocated to the legacy section. All changes are based on the following four commits:
- https://github.com/nvim-treesitter/nvim-treesitter/commit/99ddf573531c4dbe53f743ecbc1595af5eb1d32f
- https://github.com/nvim-treesitter/nvim-treesitter/commit/5d75359a9ae20c492f96e6591e3a9e229d320c87
- https://github.com/nvim-treesitter/nvim-treesitter/commit/dccf31f9b1fbbbd09e6720c7d8f5f1a2433fd32d
- https://github.com/nvim-treesitter/nvim-treesitter/commit/998b230a77b544761bae8aa7518d40b91a5c9559

I've attempted to keep the colors consistent for new additions by looking at the definitions of existing captures, but I'm _really_ not sure how to handle colors for documentation-related ones. AFAIU the only relevant existing capture is `@markup.raw`, but it seems better suited for smaller sections of documentation. Personally, I don't think a large block of greenish-blue would look great for extensive documents that might span multiple lines. Here's a comparison:

- `["@comment.documentation"] = { link = "Comment" }`:

<img width="500" alt="bef" src="https://github.com/catppuccin/nvim/assets/50296129/8347735d-bcf4-4ad1-b68b-21774bd3f1c1">

- `["@comment.documentation"] = { fg = C.teal, style = O.styles.strings or {} }`:

<img width="500" alt="aft" src="https://github.com/catppuccin/nvim/assets/50296129/f7c07c8f-7c58-4de0-99d7-bc169fab0aa7">

Note: Relevant hl groups include `@string.documentation`, `@comment.documentation`, and `@markup.raw`.

Which option are you all leaning towards? Let me know because I really can't make a choice 🥲