### PR TITLE
feat: add lir.nvim and lir-git-status.nvim integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,20 @@ lightspeed = false
 ```
 <!-- lightspeed.nvim -->
 
+<!-- lir.nvim -->
+</tr>
+<tr>
+<td> <a href="https://github.com/tamago324/lir.nvim">lir.nvim</a> </td>
+<td>
+
+```lua
+lir = {
+    enabled = false,
+    git_status = false
+}
+```
+<!-- lir.nvim -->
+
 <!-- lspsaga.nvim -->
 </tr>
 <tr>

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -580,6 +580,13 @@ lightspeed.nvim>lua
     lightspeed = false
 <
 
+lir.nvim>lua
+    lir = {
+      enabled = false,
+      git_status = false
+    }
+<
+
 lspsaga.nvim>lua
     lsp_saga = false
 <

--- a/lua/catppuccin/groups/integrations/lir.lua
+++ b/lua/catppuccin/groups/integrations/lir.lua
@@ -1,0 +1,26 @@
+local M = {}
+
+function M.get()
+  return vim.tbl_deep_extend("force", {}, {
+    LirFloatNormal = { fg = C.text, bg = O.transparent_background and C.none or C.mantle },
+    LirFloatBorder = {
+      fg = O.transparent_background and C.surface1 or C.base,
+      bg = O.transparent_background and C.none or C.base
+    },
+    LirFloatCursorLine = { link = "CursorLine" },
+    LirDir = { fg = C.blue },
+    LirSymLink = { fg = C.pink },
+    LirEmptyDirText = { fg = C.blue },
+    LirFloatCurdirWindowNormal = { fg = C.text },
+    LirFloatCurdirWindowDirName = { fg = C.lavender, style = { "bold" } }
+  }, ((O.integrations.lir and O.integrations.lir.git_status) and {
+    LirGitStatusBracket = { fg = C.overlay0 },
+    LirGitStatusIndex = { fg = C.blue },
+    LirGitStatusWorktree = { fg = C.yellow },
+    LirGitStatusUnmerged = { fg = C.red },
+    LirGitStatusUntracked = { fg = C.subtext0 },
+    LirGitStatusIgnored = { fg = C.subtext0 }
+  }) or {})
+end
+
+return M

--- a/lua/catppuccin/groups/integrations/lir.lua
+++ b/lua/catppuccin/groups/integrations/lir.lua
@@ -1,26 +1,26 @@
 local M = {}
 
 function M.get()
-  return vim.tbl_deep_extend("force", {}, {
-    LirFloatNormal = { fg = C.text, bg = O.transparent_background and C.none or C.mantle },
-    LirFloatBorder = {
-      fg = O.transparent_background and C.surface1 or C.base,
-      bg = O.transparent_background and C.none or C.base
-    },
-    LirFloatCursorLine = { link = "CursorLine" },
-    LirDir = { fg = C.blue },
-    LirSymLink = { fg = C.pink },
-    LirEmptyDirText = { fg = C.blue },
-    LirFloatCurdirWindowNormal = { fg = C.text },
-    LirFloatCurdirWindowDirName = { fg = C.lavender, style = { "bold" } }
-  }, ((O.integrations.lir and O.integrations.lir.git_status) and {
-    LirGitStatusBracket = { fg = C.overlay0 },
-    LirGitStatusIndex = { fg = C.blue },
-    LirGitStatusWorktree = { fg = C.yellow },
-    LirGitStatusUnmerged = { fg = C.red },
-    LirGitStatusUntracked = { fg = C.subtext0 },
-    LirGitStatusIgnored = { fg = C.subtext0 }
-  }) or {})
+	return vim.tbl_deep_extend("force", {}, {
+		LirFloatNormal = { fg = C.text, bg = O.transparent_background and C.none or C.mantle },
+		LirFloatBorder = {
+			fg = O.transparent_background and C.surface1 or C.base,
+			bg = O.transparent_background and C.none or C.base,
+		},
+		LirFloatCursorLine = { link = "CursorLine" },
+		LirDir = { fg = C.blue },
+		LirSymLink = { fg = C.pink },
+		LirEmptyDirText = { fg = C.blue },
+		LirFloatCurdirWindowNormal = { fg = C.text },
+		LirFloatCurdirWindowDirName = { fg = C.lavender, style = { "bold" } },
+	}, ((O.integrations.lir and O.integrations.lir.git_status) and {
+		LirGitStatusBracket = { fg = C.overlay0 },
+		LirGitStatusIndex = { fg = C.blue },
+		LirGitStatusWorktree = { fg = C.yellow },
+		LirGitStatusUnmerged = { fg = C.red },
+		LirGitStatusUntracked = { fg = C.subtext0 },
+		LirGitStatusIgnored = { fg = C.subtext0 },
+	}) or {})
 end
 
 return M

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -158,6 +158,7 @@
 ---@field indent_blankline CtpIntegrationIndentBlankline | boolean?
 ---@field leap boolean?
 ---@field lightspeed boolean?
+---@field lir CtpIntegrationLir | boolean?
 -- For custom Lsp kind icon and colors, adjust your `lspsaga` config:
 --
 -- ```lua
@@ -234,6 +235,12 @@
 -- Enables char highlights per indent level.
 -- Follow the instructions on the plugins GitHub repo to set it up.
 ---@field colored_indent_levels boolean?
+
+---@class CtpIntegrationLir
+-- Whether to enable the integration.
+---@field enabled boolean
+-- Sets lir-git-status.nvim highlight groups
+---@field git_status boolean
 
 ---@class CtpIntegrationMini
 -- Whether to enable the integration.


### PR DESCRIPTION
highlights used by [lir.nvim](https://github.com/tamago324/lir.nvim) and it's [lir-git-status.nvim](https://github.com/tamago324/lir-git-status.nvim) extension.