### PR TITLE
Support new "Ok" diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,12 +439,14 @@ native_lsp = {
         hints = { "italic" },
         warnings = { "italic" },
         information = { "italic" },
+        ok = { "italic" },
     },
     underlines = {
         errors = { "underline" },
         hints = { "underline" },
         warnings = { "underline" },
         information = { "underline" },
+        ok = { "underline" },
     },
     inlay_hints = {
         background = true,
@@ -1038,12 +1040,14 @@ native_lsp = {
         hints = { "italic" },
         warnings = { "italic" },
         information = { "italic" },
+        ok = { "italic" },
     },
     underlines = {
         errors = { "underline" },
         hints = { "underline" },
         warnings = { "underline" },
         information = { "underline" },
+        ok = { "underline" },
     },
     inlay_hints = {
         background = true,

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -366,12 +366,14 @@ directly at the thing (e.g. an error)).
             hints = { "italic" },
             warnings = { "italic" },
             information = { "italic" },
+            ok = { "italic" },
         },
         underlines = {
             errors = { "underline" },
             hints = { "underline" },
             warnings = { "underline" },
             information = { "underline" },
+            ok = { "underline" },
         },
         inlay_hints = {
             background = true,
@@ -674,12 +676,14 @@ nvim-lspconfig>lua
             hints = { "italic" },
             warnings = { "italic" },
             information = { "italic" },
+            ok = { "italic" },
         },
         underlines = {
             errors = { "underline" },
             hints = { "underline" },
             warnings = { "underline" },
             information = { "underline" },
+            ok = { "underline" },
         },
         inlay_hints = {
             background = true,

--- a/lua/catppuccin/groups/integrations/native_lsp.lua
+++ b/lua/catppuccin/groups/integrations/native_lsp.lua
@@ -9,6 +9,7 @@ function M.get()
 	local warning = C.yellow
 	local info = C.sky
 	local hint = C.teal
+	local ok = C.green
 	local darkening_percentage = 0.095
 
 	return {
@@ -40,27 +41,35 @@ function M.get()
 			fg = hint,
 			style = virtual_text.hints,
 		}, -- Used as the mantle highlight group. Other Diagnostic highlights link to this by default
+		DiagnosticVirtualTextOk = {
+			bg = O.transparent_background and C.none or U.darken(hint, darkening_percentage, C.base),
+			fg = ok,
+			style = virtual_text.ok,
+		}, -- Used as the mantle highlight group. Other Diagnostic highlights link to this by default
 
 		DiagnosticError = { bg = C.none, fg = error, style = virtual_text.errors }, -- Used as the mantle highlight group. Other Diagnostic highlights link to this by default
 		DiagnosticWarn = { bg = C.none, fg = warning, style = virtual_text.warnings }, -- Used as the mantle highlight group. Other Diagnostic highlights link to this by default
 		DiagnosticInfo = { bg = C.none, fg = info, style = virtual_text.information }, -- Used as the mantle highlight group. Other Diagnostic highlights link to this by default
 		DiagnosticHint = { bg = C.none, fg = hint, style = virtual_text.hints }, -- Used as the mantle highlight group. Other Diagnostic highlights link to this by default
+		DiagnosticOk = { bg = C.none, fg = ok, style = virtual_text.ok }, -- Used as the mantle highlight group. Other Diagnostic highlights link to this by default
 
-		-- for nvim nightly
 		DiagnosticUnderlineError = { style = underlines.errors, sp = error }, -- Used to underline "Error" diagnostics
 		DiagnosticUnderlineWarn = { style = underlines.warnings, sp = warning }, -- Used to underline "Warn" diagnostics
 		DiagnosticUnderlineInfo = { style = underlines.information, sp = info }, -- Used to underline "Info" diagnostics
 		DiagnosticUnderlineHint = { style = underlines.hints, sp = hint }, -- Used to underline "Hint" diagnostics
+		DiagnosticUnderlineOk = { style = underlines.ok, sp = ok }, -- Used to underline "Ok" diagnostics
 
 		DiagnosticFloatingError = { fg = error }, -- Used to color "Error" diagnostic messages in diagnostics float
 		DiagnosticFloatingWarn = { fg = warning }, -- Used to color "Warn" diagnostic messages in diagnostics float
 		DiagnosticFloatingInfo = { fg = info }, -- Used to color "Info" diagnostic messages in diagnostics float
 		DiagnosticFloatingHint = { fg = hint }, -- Used to color "Hint" diagnostic messages in diagnostics float
+		DiagnosticFloatingOk = { fg = ok }, -- Used to color "Ok" diagnostic messages in diagnostics float
 
 		DiagnosticSignError = { fg = error }, -- Used for "Error" signs in sign column
 		DiagnosticSignWarn = { fg = warning }, -- Used for "Warn" signs in sign column
 		DiagnosticSignInfo = { fg = info }, -- Used for "Info" signs in sign column
 		DiagnosticSignHint = { fg = hint }, -- Used for "Hint" signs in sign column
+		DiagnosticSignOk = { fg = ok }, -- Used for "Ok" signs in sign column
 
 		LspDiagnosticsDefaultError = { fg = error }, -- Used as the mantle highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
 		LspDiagnosticsDefaultWarning = { fg = warning }, -- Used as the mantle highlight group. Other LspDiagnostic highlights link to this by default (except Underline)

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -78,12 +78,14 @@ local M = {
 					hints = { "italic" },
 					warnings = { "italic" },
 					information = { "italic" },
+					ok = { "italic" },
 				},
 				underlines = {
 					errors = { "underline" },
 					hints = { "underline" },
 					warnings = { "underline" },
 					information = { "underline" },
+					ok = { "underline" },
 				},
 				inlay_hints = {
 					background = true,

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -87,14 +87,16 @@
 ---@field miscs CtpHighlightArgs[]?
 
 ---@class CtpNativeLspStyles
--- Change the style of LSP errors.
+-- Change the style of LSP error diagnostics.
 ---@field errors CtpHighlightArgs[]?
--- Change the style of LSP hints.
+-- Change the style of LSP hint diagnostics.
 ---@field hints CtpHighlightArgs[]?
--- Change the style of LSP warnings.
+-- Change the style of LSP warning diagnostics.
 ---@field warnings CtpHighlightArgs[]?
--- Change the style of LSP information.
+-- Change the style of LSP information diagnostics.
 ---@field information CtpHighlightArgs[]?
+-- Change the style of LSP ok diagnostics.
+---@field ok CtpHighlightArgs[]?
 
 ---@class CtpNativeLspInlayHints
 -- Toggle the background of inlay hints.


### PR DESCRIPTION
This diagnostic type was introduced with Neovim 0.10, and, as far as I can tell,
they are only used in `:checkhealth` for now.

I believe teal may be closer to the color used in the (new) default theme, but
that color is already used for hints, so I just used green instead.

I did not add this was not added to the "LspDiagnostic\*" highlights since I
could not find any documentation on whether the "Ok" diagnostic is implemented
for those. Indeed, I could not find any documentation whatsoever on the
LspDiagnostic\* highlights (grepping the Neovim source turned up no mentions of
them either). It may be worth removing those highlights altogether if they don't
show up anywhere. Furthermore, the Diagnostic highlights should be moved to
their own module, since they are an independent mechanism from the native LSP. I
could work on separating them if so desired.
