### PR TITLE
fix(neogit): link WinSeparator

### DIFF
--- a/lua/catppuccin/groups/integrations/neogit.lua
+++ b/lua/catppuccin/groups/integrations/neogit.lua
@@ -238,6 +238,9 @@ function M.get()
 		NeogitTagDistance = {
 			fg = C.blue,
 		},
+		NeogitWinSeparator = {
+			link = "WinSeparator",
+		},
 	}
 end
 


### PR DESCRIPTION
Before:
![image](https://github.com/catppuccin/nvim/assets/84649544/95784d4a-a54b-40f5-98e7-3c566786935b)
After:
![image](https://github.com/catppuccin/nvim/assets/84649544/5b18b5df-af0b-47f7-9db9-9e778d8d07b3)
