### PR TITLE
fix(defaults): Enable mini integration by default

### DIFF
--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -103,6 +103,10 @@ local M = {
 				enabled = false,
 				color = "red",
 			},
+			mini = {
+				enabled = true,
+				indentscope_color = "text",
+			},
 		},
 		color_overrides = {},
 		highlight_overrides = {},


### PR DESCRIPTION
The documentation says that mini is enabled by default, but it is not. This patch changes the defaults to match what is documented.

https://github.com/catppuccin/nvim/blob/cc8e290d4c0d572171243087f8541e49be2c8764/README.md?plain=1#L880-L885

Closes #715