### PR TITLE
feat(csv): built-in rainbow highlighting

### DIFF
--- a/lua/catppuccin/groups/syntax.lua
+++ b/lua/catppuccin/groups/syntax.lua
@@ -96,6 +96,17 @@ function M.get()
 		rainbow4 = { fg = C.green },
 		rainbow5 = { fg = C.sapphire },
 		rainbow6 = { fg = C.lavender },
+
+		-- csv
+		csvCol0 = { fg = C.red },
+		csvCol1 = { fg = C.peach },
+		csvCol2 = { fg = C.yellow },
+		csvCol3 = { fg = C.green },
+		csvCol4 = { fg = C.sky },
+		csvCol5 = { fg = C.blue },
+		csvCol6 = { fg = C.lavender },
+		csvCol7 = { fg = C.mauve },
+		csvCol8 = { fg = C.pink },
 	}
 end
 


### PR DESCRIPTION
Hello!

[Recently](https://github.com/neovim/neovim/pull/29395), neovim added support for CSV files. Here's how it looks:

![current csv support](https://github.com/catppuccin/nvim/assets/84649544/165f68a8-bb15-4000-83fb-329055b30855)

Which is fine, but I took the opportunity to define the groups in a rainbow-like manner, which I believe to be nicer:

![new, rainbow-like](https://github.com/catppuccin/nvim/assets/84649544/a0f64029-7e10-4e52-baaf-1a51c429a6f8)

In total, there are 9 groups. The colors are inspired by the `rainbowX` groups, but since there are 3 extra colors, I've split _sapphire_ into _sky_ and _blue_ and added _mauve_ and _pink_.

