### PR TITLE
feat(feline): add lazy.nvim updates module, replace deprecated API

### DIFF
--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -293,7 +293,7 @@ function M.get()
 	-- macro
 	components.active[1][12] = {
 		provider = "macro",
-		enabled = function() return vim.api.nvim_get_option "cmdheight" == 0 end,
+		enabled = function() return vim.api.nvim_get_option_value("cmdheight", { scope = "global" }) == 0 end,
 		hl = {
 			fg = sett.extras,
 			bg = sett.bkg,
@@ -304,7 +304,7 @@ function M.get()
 	-- search count
 	components.active[1][13] = {
 		provider = "search_count",
-		enabled = function() return vim.api.nvim_get_option "cmdheight" == 0 end,
+		enabled = function() return vim.api.nvim_get_option_value("cmdheight", { scope = "global" }) == 0 end,
 		hl = {
 			fg = sett.extras,
 			bg = sett.bkg,
@@ -441,7 +441,7 @@ function M.get()
 
 	components.active[3][2] = {
 		provider = function()
-			local active_clients = vim.lsp.get_active_clients { bufnr = 0 }
+			local active_clients = vim.lsp.get_clients { bufnr = 0 }
 
 			-- show an indicator that we have running lsps
 			if view.lsp.name == false and next(active_clients) ~= nil then return assets.lsp.server .. " " .. "Lsp" end

--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -139,6 +139,12 @@ function M.get()
 		return false
 	end
 
+	-- Check if lazy.nvim is installed
+	local has_lazy = function()
+		local lazy_installed, _ = pcall(require, "lazy")
+		return lazy_installed
+	end
+
 	-- #################### STATUSLINE ->
 
 	-- ######## Left
@@ -308,13 +314,18 @@ function M.get()
 
 	-- lazy.nvim updates
 	components.active[1][14] = {
-		provider = require("lazy.status").updates,
+		provider = function()
+			if has_lazy() then
+				return require("lazy.status").updates()
+			else
+				return " "
+			end
+		end,
 		enabled = function()
-			local lazy_installed, _ = pcall(require, "lazy")
-			if lazy_installed then
+			if has_lazy() then
 				return require("lazy.status").has_updates()
 			else
-				return ""
+				return false
 			end
 		end,
 		hl = {

--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -305,6 +305,24 @@ function M.get()
 		},
 		left_sep = invi_sep,
 	}
+
+	-- lazy.nvim plugin updates
+	components.active[1][14] = {
+		provider = require("lazy.status").updates,
+		enabled = function()
+			local lazypath = vim.fn.isdirectory(vim.fn.stdpath "data" .. "/lazy/lazy.nvim")
+			if lazypath then
+				return require("lazy.status").has_updates()
+			else
+				return ""
+			end
+		end,
+		hl = {
+			fg = sett.extras,
+			bg = sett.bkg,
+		},
+		left_sep = invi_sep,
+	}
 	-- Extras ------>
 
 	-- ######## Left

--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -306,12 +306,12 @@ function M.get()
 		left_sep = invi_sep,
 	}
 
-	-- lazy.nvim plugin updates
+	-- lazy.nvim updates
 	components.active[1][14] = {
 		provider = require("lazy.status").updates,
 		enabled = function()
-			local lazypath = vim.fn.isdirectory(vim.fn.stdpath "data" .. "/lazy/lazy.nvim")
-			if lazypath then
+			local lazy_installed, _ = pcall(require, "lazy")
+			if lazy_installed then
 				return require("lazy.status").has_updates()
 			else
 				return ""


### PR DESCRIPTION
Add option to show how many plugin updates has lazy.nvim in feline.

The code already checks if lazy.nvim is installed. If so, then the updates appears as a number with the package icon.

It looks like this:

<img width="417" alt="feline-plugin-updates" src="https://github.com/catppuccin/nvim/assets/39212564/0e356e0f-9bb7-4601-a5da-0affb033b9b7">
