### PR TITLE
fix(dapui): border match bg color

### DIFF
--- a/lua/catppuccin/groups/integrations/dap_ui.lua
+++ b/lua/catppuccin/groups/integrations/dap_ui.lua
@@ -12,7 +12,7 @@ function M.get()
 		DapUIStoppedThread = { fg = C.sky },
 		DapUISource = { fg = C.lavender },
 		DapUILineNumber = { fg = C.sky },
-		DapUIFloatBorder = { fg = C.sky },
+		DapUIFloatBorder = { link = "FloatBorder" },
 
 		DapUIWatchesEmpty = { fg = C.maroon },
 		DapUIWatchesValue = { fg = C.green },


### PR DESCRIPTION
Simple change following 31fcfb0

Before:
![image](https://github.com/catppuccin/nvim/assets/84649544/da725ee1-4dc2-4a21-904c-48ca224a93c9)
After:
![image](https://github.com/catppuccin/nvim/assets/84649544/97efc327-cb40-4263-84a3-138d1dd9a1fc)
