### PR TITLE
fix(leap): highlight group for `LeapLabel`

### DIFF
--- a/lua/catppuccin/groups/integrations/leap.lua
+++ b/lua/catppuccin/groups/integrations/leap.lua
@@ -6,15 +6,10 @@ function M.get()
 			fg = O.transparent_background and C.pink or U.vary_color({ latte = "#222222" }, U.brighten(C.green, 0.3)),
 			style = { "underline", "nocombine", O.transparent_background and "bold" or nil },
 		},
-		LeapLabelPrimary = {
+		LeapLabel = {
 			fg = O.transparent_background and C.green or U.vary_color({ latte = "#222222" }, C.base),
 			bg = O.transparent_background and C.none
 				or U.vary_color({ latte = U.brighten(C.red, 0.4) }, U.brighten(C.green, 0.3)),
-			style = { "nocombine", O.transparent_background and "bold" or nil },
-		},
-		LeapLabelSecondary = {
-			fg = O.transparent_background and C.blue or U.vary_color({ latte = "#222222" }, C.base),
-			bg = O.transparent_background and C.none or U.vary_color({ latte = U.brighten(C.sky, 0.3) }, C.sky),
 			style = { "nocombine", O.transparent_background and "bold" or nil },
 		},
 		LeapBackdrop = { fg = O.transparent_background and C.overlay0 or C.none },


### PR DESCRIPTION
Changes in https://github.com/ggandor/leap.nvim/commit/b75a86f14ebdb3940460bfd1a02224210eccc698 causes leap to not highlight labels found by leap.

This PR fixes it by removing `LeapLabelSecondary` and replacing `LeapLabelPrimary` with `LeapLabel`