### PR TITLE
feat(Gitsigns): Darken highlight on staged changes

### DIFF
--- a/lua/catppuccin/groups/integrations/gitsigns.lua
+++ b/lua/catppuccin/groups/integrations/gitsigns.lua
@@ -11,6 +11,10 @@ function M.get()
 			GitSignsChange = { fg = C.yellow }, -- diff mode: Changed line |diff.txt|
 			GitSignsDelete = { fg = C.red }, -- diff mode: Deleted line |diff.txt|
 
+			GitSignsStagedAdd = { fg = U.darken(C.green, 0.5, C.base) },
+			GitSignsStagedChange = { fg = U.darken(C.yellow, 0.5, C.base) },
+			GitSignsStagedDelete = { fg = U.darken(C.red, 0.5, C.base) }
+
 			GitSignsCurrentLineBlame = { fg = C.surface1 },
 
 			GitSignsAddPreview = O.transparent_background and { fg = U.darken(C.green, 0.72, C.base), bg = C.none }
@@ -41,6 +45,10 @@ function M.get()
 			GitSignsAdd = { fg = C.green }, -- diff mode: Added line |diff.txt|
 			GitSignsChange = { fg = C.yellow }, -- diff mode: Changed line |diff.txt|
 			GitSignsDelete = { fg = C.red }, -- diff mode: Deleted line |diff.txt|
+
+			GitSignsStagedAdd = { fg = U.darken(C.green, 0.5, C.base) },
+			GitSignsStagedChange = { fg = U.darken(C.yellow, 0.5, C.base) },
+			GitSignsStagedDelete = { fg = U.darken(C.red, 0.5, C.base) }
 
 			GitSignsCurrentLineBlame = { fg = C.surface1 },
 


### PR DESCRIPTION
Hi,
Many thanks for the colorscheme!

I changed the highlight groups for staged changes into darker version of the unstaged changes.

## Previously it looked like this:

unstaged, following GitSignsAdd/GitSignsChange/GitSignsDelete
![grafik](https://github.com/catppuccin/nvim/assets/19535699/f5382d92-1435-4a14-a09b-9ca78d38e3ed)

staged, no clue what highlight group this linked to, prob DiffAdded or something like this
![grafik](https://github.com/catppuccin/nvim/assets/19535699/6d1e006a-7bb8-401e-905c-4c8a92aa4bab)


## Now it looks like this:
unstaged:
![grafik](https://github.com/catppuccin/nvim/assets/19535699/dc234de8-5813-45e7-9cd2-cfc12879b0d1)
staged: following GitSignsStagedAdd/GitSignsStagedChange/GitSignsStagedDelete
![grafik](https://github.com/catppuccin/nvim/assets/19535699/b531a561-d944-427d-ab80-6a06c7364d0a)


As you can see, the sign gutter color just darkens.

This relies on the undocumented highlight groups of GitSignsStaged...
They are not mentioned in the README and do not have a help tag.

There are also more, for in-line highlighting and number column highlighting but I dont use those features so did not include the corresponding highlight groups.

## Bonus
This is the code snippet I used to get the same effect without this PR being merged.
```lua
		custom_highlights = function(colors)
			local utils = require 'catppuccin.utils.colors'
			return {
				GitSignsStagedAdd = { fg = utils.darken(colors.green, 0.5, colors.base) },
				GitSignsStagedChange = { fg = utils.darken(colors.yellow, 0.5, colors.base) },
				GitSignsStagedDelete = { fg = utils.darken(colors.red, 0.5, colors.base) }
			}
		end,
```