### PR TITLE
feat(feline): allow to hide lazy.nvim updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,8 @@ ctp_feline.setup({
         extras = clrs.overlay1,
         curr_file = clrs.maroon,
         curr_dir = clrs.flamingo,
-        show_modified = true -- show if the file has been modified
+        show_modified = false -- show if the file has been modified
+        show_lazy_updates = true -- show the count of updatable plugins from lazy.nvim
     },
     mode_colors = {
         ["n"] = { "NORMAL", clrs.lavender },

--- a/README.md
+++ b/README.md
@@ -582,7 +582,9 @@ ctp_feline.setup({
         curr_file = clrs.maroon,
         curr_dir = clrs.flamingo,
         show_modified = false -- show if the file has been modified
-        show_lazy_updates = true -- show the count of updatable plugins from lazy.nvim
+        show_lazy_updates = false -- show the count of updatable plugins from lazy.nvim
+                                  -- need to set checker.enabled = true in lazy.nvim first
+                                  -- the icon is set in ui.icons.plugin in lazy.nvim
     },
     mode_colors = {
         ["n"] = { "NORMAL", clrs.lavender },

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -118,7 +118,7 @@ options and settings.
             -- For more plugins integrations please scroll down (https://github.com/catppuccin/nvim#integrations)
         },
     })
-    
+
     -- setup must be called before loading
     vim.cmd.colorscheme "catppuccin"
 <
@@ -409,9 +409,9 @@ Update your Feline config to use the Catppuccin components:
 
 >lua
     local ctp_feline = require('catppuccin.groups.integrations.feline')
-    
+
     ctp_feline.setup()
-    
+
     require("feline").setup({
         components = ctp_feline.get(),
     })
@@ -426,7 +426,7 @@ Here are the defaults:
     local clrs = require("catppuccin.palettes").get_palette()
     local ctp_feline = require('catppuccin.groups.integrations.feline')
     local U = require "catppuccin.utils.colors"
-    
+
     ctp_feline.setup({
         assets = {
             left_separator = "",
@@ -456,7 +456,9 @@ Here are the defaults:
             curr_file = clrs.maroon,
             curr_dir = clrs.flamingo,
             show_modified = false -- show if the file has been modified
-            show_lazy_updates = true -- show the count of updatable plugins from lazy.nvim
+            show_lazy_updates = false -- show the count of updatable plugins from lazy.nvim
+                                      -- need to set checker.enabled = true in lazy.nvim first
+                                      -- the icon is set in ui.icons.plugin in lazy.nvim
         },
         mode_colors = {
             ["n"] = { "NORMAL", clrs.lavender },
@@ -659,7 +661,7 @@ Special ~
 
 >lua
     local sign = vim.fn.sign_define
-    
+
     sign("DapBreakpoint", { text = "●", texthl = "DapBreakpoint", linehl = "", numhl = ""})
     sign("DapBreakpointCondition", { text = "●", texthl = "DapBreakpointCondition", linehl = "", numhl = ""})
     sign("DapLogPoint", { text = "◆", texthl = "DapLogPoint", linehl = "", numhl = ""})

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -455,7 +455,8 @@ Here are the defaults:
             extras = clrs.overlay1,
             curr_file = clrs.maroon,
             curr_dir = clrs.flamingo,
-            show_modified = true -- show if the file has been modified
+            show_modified = false -- show if the file has been modified
+            show_lazy_updates = true -- show the count of updatable plugins from lazy.nvim
         },
         mode_colors = {
             ["n"] = { "NORMAL", clrs.lavender },

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -118,7 +118,7 @@ options and settings.
             -- For more plugins integrations please scroll down (https://github.com/catppuccin/nvim#integrations)
         },
     })
-
+    
     -- setup must be called before loading
     vim.cmd.colorscheme "catppuccin"
 <
@@ -409,9 +409,9 @@ Update your Feline config to use the Catppuccin components:
 
 >lua
     local ctp_feline = require('catppuccin.groups.integrations.feline')
-
+    
     ctp_feline.setup()
-
+    
     require("feline").setup({
         components = ctp_feline.get(),
     })
@@ -426,7 +426,7 @@ Here are the defaults:
     local clrs = require("catppuccin.palettes").get_palette()
     local ctp_feline = require('catppuccin.groups.integrations.feline')
     local U = require "catppuccin.utils.colors"
-
+    
     ctp_feline.setup({
         assets = {
             left_separator = "",
@@ -661,7 +661,7 @@ Special ~
 
 >lua
     local sign = vim.fn.sign_define
-
+    
     sign("DapBreakpoint", { text = "●", texthl = "DapBreakpoint", linehl = "", numhl = ""})
     sign("DapBreakpointCondition", { text = "●", texthl = "DapBreakpointCondition", linehl = "", numhl = ""})
     sign("DapLogPoint", { text = "◆", texthl = "DapLogPoint", linehl = "", numhl = ""})

--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -32,7 +32,7 @@ local sett = {
 	curr_file = C.maroon,
 	curr_dir = C.flamingo,
 	show_modified = false,
-	show_lazy_updates = true,
+	show_lazy_updates = false,
 }
 
 if require("catppuccin").flavour == "latte" then

--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -32,6 +32,7 @@ local sett = {
 	curr_file = C.maroon,
 	curr_dir = C.flamingo,
 	show_modified = false,
+	show_lazy_updates = true,
 }
 
 if require("catppuccin").flavour == "latte" then
@@ -137,12 +138,6 @@ function M.get()
 			end
 		end
 		return false
-	end
-
-	-- Check if lazy.nvim is installed
-	local has_lazy = function()
-		local lazy_installed, _ = pcall(require, "lazy")
-		return lazy_installed
 	end
 
 	-- #################### STATUSLINE ->
@@ -314,15 +309,9 @@ function M.get()
 
 	-- lazy.nvim updates
 	components.active[1][14] = {
-		provider = function()
-			if has_lazy() then
-				return require("lazy.status").updates()
-			else
-				return " "
-			end
-		end,
+		provider = function() return require("lazy.status").updates() end,
 		enabled = function()
-			if has_lazy() then
+			if has_lazy() and sett.show_lazy_updates then
 				return require("lazy.status").has_updates()
 			else
 				return false

--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -311,7 +311,7 @@ function M.get()
 	components.active[1][14] = {
 		provider = function() return require("lazy.status").updates() end,
 		enabled = function()
-			if has_lazy() and sett.show_lazy_updates then
+			if sett.show_lazy_updates and pcall(require, "lazy") then
 				return require("lazy.status").has_updates()
 			else
 				return false


### PR DESCRIPTION
This PR added an option to hide the count of updatable plugins from lazy.nvim, and updated the documentations for feline.nvim.

Please check this out @ilias777 :eyes: