### PR TITLE
feat(nvim-surround): add integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1145,7 +1145,7 @@ nvim_surround = true
 <td>
 
 ```lua
-nvimtree = true
+nvimtree = false
 ```
 
 </td>

--- a/README.md
+++ b/README.md
@@ -1131,7 +1131,7 @@ semantic_tokens = true
 <td>
 
 ```lua
-nvim_surround = true
+nvim_surround = false
 ```
 
 </td>
@@ -1145,7 +1145,7 @@ nvim_surround = true
 <td>
 
 ```lua
-nvimtree = false
+nvimtree = true
 ```
 
 </td>

--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,20 @@ semantic_tokens = true
 </tr>
 <!-- nvim-semantic-tokens -->
 
+<!-- nvim-surround -->
+</tr>
+<tr>
+<td> <a href="https://github.com/kylechui/nvim-surround">nvim-surround</a> </td>
+<td>
+
+```lua
+nvim_surround = true
+```
+
+</td>
+</tr>
+<!-- nvim-surround -->
+
 <!-- nvim-tree.lua -->
 </tr>
 <tr>

--- a/lua/catppuccin/groups/integrations/nvim_surround.lua
+++ b/lua/catppuccin/groups/integrations/nvim_surround.lua
@@ -1,0 +1,9 @@
+local M = {}
+
+function M.get()
+	return {
+		NvimSurroundHighlight = { bg = U.darken(C.peach, 0.6, C.base), style = { "bold" } },
+	}
+end
+
+return M

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -185,6 +185,7 @@
 ---@field neotree boolean?
 ---@field noice boolean?
 ---@field notify boolean?
+---@field nvim_surround boolean?
 ---@field nvimtree boolean?
 ---@field octo boolean?
 ---@field overseer boolean?


### PR DESCRIPTION
This is to distinguish the document highlight of LSP. NvimSurroundHighlight is linked to Visual by default, so they both have the same background color 'surface1'.

NOTE: Sometimes, LspReferenceXxxx (document highlight) color may override the NvimSurroundHighlight. I have no idea how to fix that,  need somebody to help.

Snapshot:
<img width="447" alt="WeChatWorkScreenshot_c90c974f-32ca-4f8c-958f-0135cd8558b7" src="https://github.com/user-attachments/assets/b7acb922-f881-4373-9121-e3aee50aa389">

<img width="438" alt="WeChatWorkScreenshot_29a27585-7ad9-42af-9998-0eeec79ed7b3" src="https://github.com/user-attachments/assets/4fedf0ac-6644-4a69-8c10-2d582a811a04">

<img width="456" alt="WeChatWorkScreenshot_62eaf123-6c4c-40b7-a1b3-fb6f1d673071" src="https://github.com/user-attachments/assets/cca25b78-e830-4442-bc57-c146199efb70">
