### PR TITLE
feat: add `grug-far.nvim` integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,6 +707,17 @@ gitsigns = true
 ```
 <!-- gitsigns.nvim -->
 
+<!-- grug-far.nvim -->
+</tr>
+<tr>
+<td> <a href="https://github.com/MagicDuck/grug-far.nvim">grug-far.nvim</a> </td>
+<td>
+
+```lua
+grug_far = false
+```
+<!-- grug-far.nvim -->
+
 <!-- harpoon -->
 </tr>
 <tr>

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -542,6 +542,10 @@ gitsigns.nvim>lua
     gitsigns = true
 <
 
+grug-far.nvim>lua
+    grug_far = false
+<
+
 harpoon>lua
     harpoon = false
 <

--- a/lua/catppuccin/groups/integrations/grug_far.lua
+++ b/lua/catppuccin/groups/integrations/grug_far.lua
@@ -1,0 +1,9 @@
+local M = {}
+
+function M.get()
+	return {
+		GrugFarResultsMatch = { link = "IncSearch" },
+	}
+end
+
+return M

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -151,6 +151,7 @@
 ---@field flash boolean?
 ---@field gitgutter boolean?
 ---@field gitsigns boolean?
+---@field grug_far boolean?
 ---@field harpoon boolean?
 ---@field headlines boolean?
 ---@field hop boolean?


### PR DESCRIPTION
This adds support for [grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim). Most of the highlights are solid choices out of the box, but this one should be made more visible.