### PR TITLE
fix(treesitter): highlight paths in `.gitignore` as text

### DIFF
--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -196,7 +196,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@comment.warning.gitcommit"] = { fg = C.yellow },
 
 		-- gitignore
-		["@character.special.gitignore"] = { fg = C.mauve },
+		["@string.special.path.gitignore"] = { fg = C.mauve },
 
 		-- Misc
 		gitcommitSummary = { fg = C.rosewater, style = O.styles.miscs or { "italic" } },

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -195,6 +195,9 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		-- gitcommit
 		["@comment.warning.gitcommit"] = { fg = C.yellow },
 
+		-- gitignore
+		["@character.special.gitignore"] = { fg = C.mauve },
+
 		-- Misc
 		gitcommitSummary = { fg = C.rosewater, style = O.styles.miscs or { "italic" } },
 		zshKSHFunction = { link = "Function" },

--- a/lua/catppuccin/groups/integrations/treesitter.lua
+++ b/lua/catppuccin/groups/integrations/treesitter.lua
@@ -196,7 +196,7 @@ If you want to stay on nvim 0.7, either disable the integration or pin catppucci
 		["@comment.warning.gitcommit"] = { fg = C.yellow },
 
 		-- gitignore
-		["@string.special.path.gitignore"] = { fg = C.mauve },
+		["@string.special.path.gitignore"] = { fg = C.text },
 
 		-- Misc
 		gitcommitSummary = { fg = C.rosewater, style = O.styles.miscs or { "italic" } },


### PR DESCRIPTION
Closes #734 

cc @ValdezFOmar 