### PR TITLE
docs: rename markdown.nvim to render-markdown.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1326,10 +1326,10 @@ To use another flavour just replace `mocha` with the one you want to use.
 </tr>
 <!-- reactive.nvim -->
 
-<!-- markdown.nvim -->
+<!-- render-markdown.nvim -->
 </tr>
 <tr>
-<td> <a href="https://github.com/MeanderingProgrammer/markdown.nvim">render-markdown (markdown.nvim)</a> </td>
+<td> <a href="https://github.com/MeanderingProgrammer/render-markdown.nvim">render-markdown.nvim</a> </td>
 <td>
 
 ```lua
@@ -1338,7 +1338,7 @@ render_markdown = true
 
 </td>
 </tr>
-<!-- markdown.nvim -->
+<!-- render-markdown.nvim -->
 
 <!-- symbols-outline.nvim -->
 </tr>

--- a/lua/catppuccin/groups/integrations/render_markdown.lua
+++ b/lua/catppuccin/groups/integrations/render_markdown.lua
@@ -1,7 +1,7 @@
 local M = {}
 
--- markdown.nvim highlight groups:
--- https://github.com/MeanderingProgrammer/markdown.nvim?tab=readme-ov-file#colors
+-- render-markdown.nvim highlight groups:
+-- https://github.com/MeanderingProgrammer/render-markdown.nvim?tab=readme-ov-file#colors
 
 function M.get()
 	local groups = {


### PR DESCRIPTION
The repository has been renamed: https://github.com/MeanderingProgrammer/render-markdown.nvim/commit/aeb5cec617c3bd5738ab82ba2c3f9ccdc27656c2
