### PR TITLE
feat(render-markdown): add highlights for callouts

### DIFF
--- a/lua/catppuccin/groups/integrations/render_markdown.lua
+++ b/lua/catppuccin/groups/integrations/render_markdown.lua
@@ -10,6 +10,11 @@ function M.get()
 		RenderMarkdownBullet = { fg = C.sky },
 		RenderMarkdownTableHead = { fg = C.blue },
 		RenderMarkdownTableRow = { fg = C.lavender },
+		RenderMarkdownSuccess = { fg = C.green },
+		RenderMarkdownInfo = { fg = C.sky },
+		RenderMarkdownHint = { fg = C.teal },
+		RenderMarkdownWarn = { fg = C.yellow },
+		RenderMarkdownError = { fg = C.red },
 	}
 
 	local syntax = require("catppuccin.groups.syntax").get()


### PR DESCRIPTION
Fixed an issue where the `integrations.native_lsp.virtual_text` style was being applied to callouts (italic by default).

before:
![renmarkbefore](https://github.com/user-attachments/assets/509573aa-2934-4127-a1a1-bb752acebc67)

after:
![renmarkafter](https://github.com/user-attachments/assets/4d25aa12-cbf8-4c63-bc8c-27fd207d2eae)
