### PR TITLE
feat: add vim-dadbod-ui integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,20 +477,6 @@ colorful_winsep = {
 </tr>
 <!-- colorful_winsep.nvim -->
 
-<!-- dadbod-ui -->
-</tr>
-<tr>
-<td> <a href="https://github.com/kristijanhusak/vim-dadbod-ui">dadbod-ui</a> </td>
-<td>
-
-```lua
-dadbod_ui = false
-```
-
-</td>
-</tr>
-<!-- dadbod-ui -->
-
 <!-- dashboard-nvim -->
 </tr>
 <tr>
@@ -1481,6 +1467,20 @@ let g:clap_theme = 'catppuccin'
 </td>
 </tr>
 <!-- vim-clap -->
+
+<!-- vim-dadbod-ui -->
+</tr>
+<tr>
+<td> <a href="https://github.com/kristijanhusak/vim-dadbod-ui">vim-dadbod-ui</a> </td>
+<td>
+
+```lua
+dadbod_ui = false
+```
+
+</td>
+</tr>
+<!-- vim-dadbod-ui -->
 
 <!-- vim-gitgutter -->
 </tr>

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ colorful_winsep = {
 <td>
 
 ```lua
-dadbod_ui = true
+dadbod_ui = false
 ```
 
 </td>

--- a/README.md
+++ b/README.md
@@ -477,6 +477,20 @@ colorful_winsep = {
 </tr>
 <!-- colorful_winsep.nvim -->
 
+<!-- dadbod-ui -->
+</tr>
+<tr>
+<td> <a href="https://github.com/kristijanhusak/vim-dadbod-ui">dadbod-ui</a> </td>
+<td>
+
+```lua
+dadbod_ui = true
+```
+
+</td>
+</tr>
+<!-- dadbod-ui -->
+
 <!-- dashboard-nvim -->
 </tr>
 <tr>

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -389,7 +389,7 @@ colorful-winsep.nvim>lua
 <
 
 dadbod-ui>lua
-    dadbod_ui = true
+    dadbod_ui = false
 <
 
 dashboard-nvim>lua

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -118,7 +118,7 @@ options and settings.
             -- For more plugins integrations please scroll down (https://github.com/catppuccin/nvim#integrations)
         },
     })
-    
+
     -- setup must be called before loading
     vim.cmd.colorscheme "catppuccin"
 <
@@ -388,6 +388,10 @@ colorful-winsep.nvim>lua
     }
 <
 
+dadbod-ui>lua
+    dadbod_ui = true
+<
+
 dashboard-nvim>lua
     dashboard = true
 <
@@ -409,9 +413,9 @@ Update your Feline config to use the Catppuccin components:
 
 >lua
     local ctp_feline = require('catppuccin.groups.integrations.feline')
-    
+
     ctp_feline.setup()
-    
+
     require("feline").setup({
         components = ctp_feline.get(),
     })
@@ -426,7 +430,7 @@ Here are the defaults:
     local clrs = require("catppuccin.palettes").get_palette()
     local ctp_feline = require('catppuccin.groups.integrations.feline')
     local U = require "catppuccin.utils.colors"
-    
+
     ctp_feline.setup({
         assets = {
             left_separator = "",
@@ -676,7 +680,7 @@ Special ~
 
 >lua
     local sign = vim.fn.sign_define
-    
+
     sign("DapBreakpoint", { text = "●", texthl = "DapBreakpoint", linehl = "", numhl = ""})
     sign("DapBreakpointCondition", { text = "●", texthl = "DapBreakpointCondition", linehl = "", numhl = ""})
     sign("DapLogPoint", { text = "◆", texthl = "DapLogPoint", linehl = "", numhl = ""})

--- a/lua/catppuccin/groups/integrations/dadbod_ui.lua
+++ b/lua/catppuccin/groups/integrations/dadbod_ui.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+function M.get()
+	return {
+		NotificationInfo = { fg = C.blue, bg = C.mantle },
+		NotificationWarning = { fg = C.yellow, bg = C.mantle },
+		NotificationError = { fg = C.red, bg = C.mantle },
+	}
+end
+
+return M

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -132,6 +132,7 @@
 -- sign("DapBreakpointCondition", { text = "●", texthl = "DapBreakpointCondition", linehl = "", numhl = ""})
 -- sign("DapLogPoint", { text = "◆", texthl = "DapLogPoint", linehl = "", numhl = ""})
 -- ```
+---@field dadbod_ui boolean?
 ---@field dap boolean?
 ---@field dap_ui boolean?
 ---@field dashboard boolean?


### PR DESCRIPTION
Summary
----
This adds support for [dadbod-ui](https://github.com/kristijanhusak/vim-dadbod-ui).

I chose the following colors (mostly because it seemed reasonable):

```
NotificationInfo = { fg = C.blue, bg = C.mantle },
NotificationWarning = { fg = C.yellow, bg = C.mantle },
NotificationError = { fg = C.red, bg = C.mantle },
```

PS: There's some whitespace cleanup here as well.