### PR TITLE
fix(editor): add missing background for `TabLineFill`

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -60,7 +60,7 @@ function M.get()
 		StatusLine = { fg = C.text, bg = O.transparent_background and C.none or C.mantle }, -- status line of current window
 		StatusLineNC = { fg = C.surface1, bg = O.transparent_background and C.none or C.mantle }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
 		TabLine = { bg = C.mantle, fg = C.surface1 }, -- tab pages line, not active tab page label
-		TabLineFill = {}, -- tab pages line, where there are no labels
+		TabLineFill = { bg = O.transparent_background and C.none or C.mantle }, -- tab pages line, where there are no labels
 		TabLineSel = { fg = C.green, bg = C.surface1 }, -- tab pages line, active tab page label
 		TermCursor = { fg = C.base, bg = C.rosewater }, -- cursor in a focused terminal
 		TermCursorNC = { fg = C.base, bg = C.overlay2 }, -- cursor in unfocused terminals


### PR DESCRIPTION
It looks like `TabLineFill` background got removed at some point. This adds it back in