### PR TITLE
fix(editor): make TabLine more readable

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -59,7 +59,7 @@ function M.get()
 		SpellRare = { sp = C.green, style = { "undercurl" } }, -- Word that is recognized by the spellchecker as one that is hardly ever used.  |spell| Combined with the highlighting used otherwise.
 		StatusLine = { fg = C.text, bg = O.transparent_background and C.none or C.mantle }, -- status line of current window
 		StatusLineNC = { fg = C.surface1, bg = O.transparent_background and C.none or C.mantle }, -- status lines of not-current windows Note: if this is equal to "StatusLine" Vim will use "^^^" in the status line of the current window.
-		TabLine = { bg = C.mantle, fg = C.surface1 }, -- tab pages line, not active tab page label
+		TabLine = { bg = C.mantle, fg = C.overlay0 }, -- tab pages line, not active tab page label
 		TabLineFill = { bg = O.transparent_background and C.none or C.mantle }, -- tab pages line, where there are no labels
 		TabLineSel = { fg = C.green, bg = C.surface1 }, -- tab pages line, active tab page label
 		TermCursor = { fg = C.base, bg = C.rosewater }, -- cursor in a focused terminal


### PR DESCRIPTION
Hello!

Currently, the `TabLine` foreground is too dark, barely readable with an even darker background:

![image](https://github.com/user-attachments/assets/b5d46188-9e82-4350-a70c-fed921c6275d)

After:

![image](https://github.com/user-attachments/assets/d816e597-d7c0-4d94-b34b-354b2be4eefc)
