### PR TITLE
fix(editor): update `PmenuSel` to account for recent changes in Neovim 0.11

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -44,7 +44,7 @@ function M.get()
 			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or U.darken(C.surface0, 0.8, C.crust),
 			fg = C.overlay2,
 		}, -- Popup menu: normal item.
-		PmenuSel = { bg = C.surface1, style = { "bold" } }, -- Popup menu: selected item.
+		PmenuSel = { fg = C.surface1, bg = C.overlay2, style = { "bold", "reverse" } }, -- Popup menu: selected item.
 		PmenuSbar = { bg = C.surface1 }, -- Popup menu: scrollbar.
 		PmenuThumb = { bg = C.overlay0 }, -- Popup menu: Thumb of the scrollbar.
 		Question = { fg = C.blue }, -- |hit-enter| prompt and yes/no questions


### PR DESCRIPTION
Some new highlight changes were made on Neovim 0.11 development which can cause some weirdness with `PmenuSel`. This resolves this with a workaround

Reference:
https://www.reddit.com/r/neovim/comments/1f439w8/psa_for_color_scheme_authors_you_might_want_to/
