### PR TITLE
fix(syntax): use `overlay2` for comments

### DIFF
--- a/lua/catppuccin/groups/syntax.lua
+++ b/lua/catppuccin/groups/syntax.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.get()
 	return {
-		Comment = { fg = C.overlay0, style = O.styles.comments }, -- just comments
+		Comment = { fg = C.overlay2, style = O.styles.comments }, -- just comments
 		SpecialComment = { link = "Special" }, -- special things inside a comment
 		Constant = { fg = C.peach }, -- (preferred) any constant
 		String = { fg = C.green, style = O.styles.strings or {} }, -- a string constant: "this is a string"


### PR DESCRIPTION
Teeny change from overlay0 to overlay2 for comments to match the [style guide](https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md#code-editors).