### PR TITLE
feat: add background highlight to LSP signature help

### DIFF
--- a/lua/catppuccin/groups/integrations/native_lsp.lua
+++ b/lua/catppuccin/groups/integrations/native_lsp.lua
@@ -75,7 +75,7 @@ function M.get()
 		LspDiagnosticsDefaultWarning = { fg = warning }, -- Used as the mantle highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
 		LspDiagnosticsDefaultInformation = { fg = info }, -- Used as the mantle highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
 		LspDiagnosticsDefaultHint = { fg = hint }, -- Used as the mantle highlight group. Other LspDiagnostic highlights link to this by default (except Underline)
-		LspSignatureActiveParameter = { fg = C.peach },
+		LspSignatureActiveParameter = { bg = C.surface0, style = { "bold" } },
 		-- LspDiagnosticsFloatingError         = { }, -- Used to color "Error" diagnostic messages in diagnostics float
 		-- LspDiagnosticsFloatingWarning       = { }, -- Used to color "Warning" diagnostic messages in diagnostics float
 		-- LspDiagnosticsFloatingInformation   = { }, -- Used to color "Information" diagnostic messages in diagnostics float


### PR DESCRIPTION
I used surface1 as the color, the same as those used by LspReferenceText, LspReferenceRead, and LspReferenceWrite.

This change helps to highlight the current parameter under the cursor when invoking `vim.lsp.buf.signature_help`.

## Before the change
`name: string` has a peach foreground but the same background as the other parameters, making it hard to distinguish.
![image](https://github.com/user-attachments/assets/7dab3ab6-846b-402a-b751-0c44bd270daa)

## After the change
`name: string` has a peach foreground and a surface1 background, making distinguishing from the other parameters easier.
![image](https://github.com/user-attachments/assets/fc064762-bbfe-44e3-a8d4-2033065078d0)
