### PR TITLE
feat(render-markdown): change code block background to `mantle`

### DIFF
--- a/lua/catppuccin/groups/integrations/render_markdown.lua
+++ b/lua/catppuccin/groups/integrations/render_markdown.lua
@@ -5,8 +5,8 @@ local M = {}
 
 function M.get()
 	local groups = {
-		RenderMarkdownCode = { bg = C.surface0 },
-		RenderMarkdownCodeInline = { bg = C.surface1 },
+		RenderMarkdownCode = { bg = C.mantle },
+		RenderMarkdownCodeInline = { bg = C.surface0 },
 		RenderMarkdownBullet = { fg = C.sky },
 		RenderMarkdownTableHead = { fg = C.blue },
 		RenderMarkdownTableRow = { fg = C.lavender },


### PR DESCRIPTION
Although this may seem like a very subjective change, it is not. There's two reasons:

1. render-markdown itself uses a similar color in its README like:
![image](https://github.com/user-attachments/assets/9b6c14fc-ed21-443b-bb22-7513c546816b)

2. neovim's `vim.lsp.buf.hover` uses markdown to render colors, so the colder blocks should be better to use the same color with `NormalFloat`, otherwise the color is awful:
  * before: ![image](https://github.com/user-attachments/assets/6261f62c-8397-431f-8e37-4fd0c4e67b36)
  * after: ![image](https://github.com/user-attachments/assets/2656efe3-38d5-4f07-9bd9-65af9f785d09)


