### PR TITLE
fix(colorful-winsep): respect transparent_background configuration

### DIFF
--- a/lua/catppuccin/groups/integrations/colorful_winsep.lua
+++ b/lua/catppuccin/groups/integrations/colorful_winsep.lua
@@ -2,7 +2,10 @@ local M = {}
 
 function M.get()
 	return {
-		NvimSeparator = { bg = C.base, fg = C[O.integrations.colorful_winsep.color] },
+		NvimSeparator = {	
+			fg = C[O.integrations.colorful_winsep.color],
+			bg = O.transparent_background and C.none or C.base
+		},
 	}
 end
 


### PR DESCRIPTION
The background color should be transparent ('none') if config option is set.
