### PR TITLE
fix(dap-ui): add colors for *NC hlgroups of UI controls

### DIFF
--- a/lua/catppuccin/groups/integrations/dap_ui.lua
+++ b/lua/catppuccin/groups/integrations/dap_ui.lua
@@ -24,13 +24,21 @@ function M.get()
 		DapUIBreakpointsDisabledLine = { fg = C.surface2 },
 
 		DapUIStepOver = { fg = C.blue },
+		DapUIStepOverNC = { link = "DapUIStepOver" },
 		DapUIStepInto = { fg = C.blue },
+		DapUIStepIntoNC = { link = "DapUIStepInto" },
 		DapUIStepBack = { fg = C.blue },
+		DapUIStepBackNC = { link = "DapUIStepBack" },
 		DapUIStepOut = { fg = C.blue },
+		DapUIStepOutNC = { link = "DapUIStepOut" },
 		DapUIStop = { fg = C.red },
+		DapUIStopNC = { link = "DapUIStop" },
 		DapUIPlayPause = { fg = C.green },
+		DapUIPlayPauseNC = { link = "DapUIPlayPause" },
 		DapUIRestart = { fg = C.green },
+		DapUIRestartNC = { link = "DapUIRestart" },
 		DapUIUnavailable = { fg = C.surface1 },
+		DapUIUnavailableNC = { link = "DapUIUnavailable" },
 
 		DapUIWinSelect = { fg = C.peach },
 	}


### PR DESCRIPTION
`nvim-dap-ui` has highlight groups for all its buttons: `DapUIPlayPause`, `DapUIStepOver`, etc. But it also has `*NC` versions of those highlights. I assume NC stands for non-current or "no cursor".

`nvim-dap-ui` defaults to linking those to their non-`*NC` versions but I assume it happens too early and Catppuccin does not pick that up. This PR simply duplicates the highlight groups to include `*NC` versions.

See https://github.com/rcarriga/nvim-dap-ui/blob/ffa89839f97bad360e78428d5c740fdad9a0ff02/lua/dapui/config/highlights.lua#L75-L96

## Before

![Screenshot_20241020_111017](https://github.com/user-attachments/assets/8d861c01-64fa-4824-96da-1c719349e6b1)
![Screenshot_20241020_110955](https://github.com/user-attachments/assets/5fa03cf9-c80a-4a40-b6d6-bf896188d558)

## After

![Screenshot_20241020_110436](https://github.com/user-attachments/assets/38643d59-2b1c-4395-8e11-3bd0be43ee55)
![Screenshot_20241020_110432](https://github.com/user-attachments/assets/6cdff591-1782-4ef6-a14f-388ed1001657)