### PR TITLE
docs(integrations): reflect that `neotree` is enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,7 +951,7 @@ mini = {
 <td>
 
 ```lua
-neotree = false
+neotree = true
 ```
 
 </td>


### PR DESCRIPTION
Document neotree as being an integration that is active by default.
ref: [#c536623](https://github.com/catppuccin/nvim/commit/c536623eac60f8443c93ae4ca0e03b51574b5f50)
