### PR TITLE
fix(render-markdown): remove backgrounds for H<n>

### DIFF
--- a/lua/catppuccin/groups/integrations/render_markdown.lua
+++ b/lua/catppuccin/groups/integrations/render_markdown.lua
@@ -23,7 +23,6 @@ function M.get()
 	for i = 1, 6 do
 		local color = syntax["rainbow" .. i].fg
 		groups["RenderMarkdownH" .. i] = { fg = color }
-		groups["RenderMarkdownH" .. i .. "Bg"] = { bg = U.darken(color, 0.30, base) }
 	end
 
 	return groups


### PR DESCRIPTION
The background colors for headers are barely readable in light theme, and it doesn’t look to make any difference in dark theme.

## Before

<img width="2053" alt="image" src="https://github.com/user-attachments/assets/21287f4a-cf98-488d-8459-82bb86a5a03c">

<img width="2038" alt="image" src="https://github.com/user-attachments/assets/9a40bd78-06c2-469d-a792-c615324366cd">

## After

<img width="2034" alt="image" src="https://github.com/user-attachments/assets/143ca70e-8edc-4c60-ba80-ec64c4aba7f9">

<img width="2053" alt="image" src="https://github.com/user-attachments/assets/406f0d38-6b92-4838-9e84-b75d58c63630">
