### PR TITLE
fix(blink-cmp): follow `Pmenu` highlights

### DIFF
--- a/lua/catppuccin/groups/integrations/blink_cmp.lua
+++ b/lua/catppuccin/groups/integrations/blink_cmp.lua
@@ -2,7 +2,6 @@ local M = {}
 
 function M.get()
 	return {
-		BlinkCmpMenu = { fg = C.text },
 		BlinkCmpLabel = { fg = C.overlay2 },
 		BlinkCmpLabelDeprecated = { fg = C.overlay0, style = { "strikethrough" } },
 

--- a/lua/catppuccin/groups/integrations/blink_cmp.lua
+++ b/lua/catppuccin/groups/integrations/blink_cmp.lua
@@ -2,13 +2,9 @@ local M = {}
 
 function M.get()
 	return {
-		BlinkCmpMenu = { fg = C.text, bg = O.transparent_background and C.none or C.base },
-		BlinkCmpMenuBorder = { fg = C.overlay0, bg = O.transparent_background and C.none or C.base },
-		BlinkCmpMenuSelection = { bg = C.surface0 },
-		BlinkCmpLabel = { fg = C.text },
+		BlinkCmpMenu = { fg = C.text },
+		BlinkCmpLabel = { fg = C.overlay2 },
 		BlinkCmpLabelDeprecated = { fg = C.overlay0, style = { "strikethrough" } },
-		BlinkCmpDocBorder = { fg = C.overlay0, bg = O.transparent_background and C.none or C.base },
-		BlinkCmpDoc = { fg = C.text, bg = O.transparent_background and C.none or C.base },
 
 		BlinkCmpKindText = { fg = C.green },
 		BlinkCmpKindMethod = { fg = C.blue },


### PR DESCRIPTION
Closes #797 .

![20241102_20h20m43s_grim](https://github.com/user-attachments/assets/0025d6be-01fb-455c-af6a-443b4d7f6730)

_Shadow comes from Neovide_

@giuxtaposition We've decided to prioritize the default UI over the bordered one, and the ones who likes it bordered need to override the highlights by themselves now.