### PR TITLE
fix(nvim-surround): bg conflicts with document highlight

### DIFF
--- a/lua/catppuccin/groups/integrations/nvim_surround.lua
+++ b/lua/catppuccin/groups/integrations/nvim_surround.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.get()
 	return {
-		NvimSurroundHighlight = { bg = U.darken(C.peach, 0.6, C.base), style = { "bold" } },
+		NvimSurroundHighlight = { sp = C.peach, style = { "underline" } },
 	}
 end
 


### PR DESCRIPTION
nvim-surround highlight is sometimes covered by document highlight, so using underline to resolve the conflict.

before:
<img width="306" alt="WeChatWorkScreenshot_e1da7a78-f417-499d-8100-8a82caeb18f6" src="https://github.com/user-attachments/assets/041eaa97-be56-4231-876b-85af4f8ebbac">

after:
<img width="252" alt="WeChatWorkScreenshot_171a1b5c-ee98-4603-a176-9cce11e01ca6" src="https://github.com/user-attachments/assets/1f8a5199-b566-4497-b92a-db9faf204006">

