### PR TITLE
feat(blink-cmp): support `BlinkCmpLabelMatch` hl

### DIFF
--- a/lua/catppuccin/groups/integrations/blink_cmp.lua
+++ b/lua/catppuccin/groups/integrations/blink_cmp.lua
@@ -5,6 +5,7 @@ function M.get()
 		BlinkCmpLabel = { fg = C.overlay2 },
 		BlinkCmpLabelDeprecated = { fg = C.overlay0, style = { "strikethrough" } },
 
+		BlinkCmpLabelMatch = { fg = C.text, style = { "bold" } },
 		BlinkCmpKindText = { fg = C.green },
 		BlinkCmpKindMethod = { fg = C.blue },
 		BlinkCmpKindFunction = { fg = C.blue },


### PR DESCRIPTION
This PR adds the blink cmp matching highlight group

Source:
https://github.com/Saghen/blink.cmp/blob/6516736e15eb0ca0120df2dc11528cb2d257092e/README.md?plain=1#L144

I copied the styling from the nvim-cmp integration

https://github.com/catppuccin/nvim/blob/35d8057137af463c9f41f169539e9b190d57d269/lua/catppuccin/groups/integrations/cmp.lua#L9C57-L9C58

<details>
<summary>Before</summary>

![image](https://github.com/user-attachments/assets/67b4dfd8-b3bf-430d-8bb5-79b6054343cf)


</details>

<details>
<summary>After</summary>

![image](https://github.com/user-attachments/assets/60f7da81-2456-44bc-9863-166d231a2a84)


</details>