### PR TITLE
feat(gitsign): improve gitsign inline add and delete colors

### DIFF
--- a/lua/catppuccin/groups/integrations/gitsigns.lua
+++ b/lua/catppuccin/groups/integrations/gitsigns.lua
@@ -46,6 +46,9 @@ function M.get()
 
 			GitSignsAddPreview = O.transparent_background and { fg = C.green, bg = C.none } or { link = "DiffAdd" },
 			GitSignsDeletePreview = O.transparent_background and { fg = C.red, bg = C.none } or { link = "DiffDelete" },
+
+			GitSignsAddInline = { bg = U.darken(C.green, 0.36, C.base) },
+			GitSignsDeleteInline = { bg = U.darken(C.red, 0.36, C.base) },
 		}
 	end
 end


### PR DESCRIPTION
This PR aims to improve the colors of changed text when running `:Gitsigns preview_hunk` with `transparent_background = false` (see the screenshot below).

For the dark themes, the cursor color seems to "conflict" with the diff colors, making it hard to track the cursor if focusing a hunk and, e.g., copying some text.

For `GitSignsAddInline`, it took the color of https://github.com/catppuccin/nvim/blob/faf15ab0201b564b6368ffa47b56feefc92ce3f4/lua/catppuccin/groups/syntax.lua#L73 and doubled the amount from `18` to `36`. I did the same with `GitSignsDeleteInline` and https://github.com/catppuccin/nvim/blob/faf15ab0201b564b6368ffa47b56feefc92ce3f4/lua/catppuccin/groups/syntax.lua#L75

# Latte

## Before

![image](https://github.com/user-attachments/assets/62c28134-838c-454a-9368-befafac8b786)

## After

![image](https://github.com/user-attachments/assets/af340b60-86ee-4b38-a889-6d4b0a8a9bce)

# Frappe

## Before

![image](https://github.com/user-attachments/assets/163c021a-828c-44d0-9679-0944c3722ea0)

## After

![image](https://github.com/user-attachments/assets/91020b14-2d7f-47dd-9df2-817c22f5c1db)

# Macchiato

## Before

![image](https://github.com/user-attachments/assets/263f9ff4-a110-4ba8-9dd7-cc78483fc01a)

## After

![image](https://github.com/user-attachments/assets/c7c90d3d-84a0-4502-9632-69fbd4c54fe5)

# Mocha

## Before

![image](https://github.com/user-attachments/assets/43635d71-8966-434d-8048-86f1f21b89b3)

## After

![image](https://github.com/user-attachments/assets/36bde8df-8984-4dd4-9d4a-4aea384ec820)