### PR TITLE
feat(blink-cmp): improve styling support

### DIFF
--- a/lua/catppuccin/groups/integrations/blink_cmp.lua
+++ b/lua/catppuccin/groups/integrations/blink_cmp.lua
@@ -9,6 +9,7 @@ function M.get()
 		BlinkCmpMenuBorder = { fg = C.blue },
 		BlinkCmpDocBorder = { fg = C.blue },
 		BlinkCmpSignatureHelpActiveParameter = { fg = C.mauve },
+		BlinkCmpSignatureHelpBorder = { fg = C.blue },
 
 		BlinkCmpLabelMatch = { fg = C.text, style = { "bold" } },
 		BlinkCmpKindText = { fg = C.green },

--- a/lua/catppuccin/groups/integrations/blink_cmp.lua
+++ b/lua/catppuccin/groups/integrations/blink_cmp.lua
@@ -4,6 +4,11 @@ function M.get()
 	return {
 		BlinkCmpLabel = { fg = C.overlay2 },
 		BlinkCmpLabelDeprecated = { fg = C.overlay0, style = { "strikethrough" } },
+		BlinkCmpKind = { fg = C.blue },
+		BlinkCmpMenu = { fg = C.text },
+		BlinkCmpMenuBorder = { fg = C.blue },
+		BlinkCmpDocBorder = { fg = C.blue },
+		BlinkCmpSignatureHelpActiveParameter = { fg = C.mauve },
 
 		BlinkCmpLabelMatch = { fg = C.text, style = { "bold" } },
 		BlinkCmpKindText = { fg = C.green },


### PR DESCRIPTION
add hl groups for BlinkCmpKind, BlinkCmpMenu, BlinkCmpMenuBorder, BlinkCmpDocBorder, BlinkCmpSignatureHelpActiveParameter

- This was the previous styling for blink.cmp, it didn't have the correct background color for the completion menu, no border styling and no styling for showing the current signaturehelp item.
![Screenshot_20241210_163953](https://github.com/user-attachments/assets/72e68850-7188-4288-be3b-70630487cc10)

- This is how it looks after the new hl group additions:
![image](https://github.com/user-attachments/assets/0ff0bce4-f0a4-4dd0-9060-ada22555922e)

- All styling colors were taken from previous nvim-cmp styling and the catppuccin vscode theme.

