### PR TITLE
fix: match fzf-lua highlights to telescope

### DIFF
--- a/lua/catppuccin/groups/integrations/fzf.lua
+++ b/lua/catppuccin/groups/integrations/fzf.lua
@@ -2,11 +2,14 @@ local M = {}
 
 function M.get()
 	return {
-		FzfLuaNormal = { link = "NormalFloat" },
+		-- FzfLuaNormal = { link = "NormalFloat" }, Respect fzf-lua's default float bg
 		FzfLuaBorder = { link = "FloatBorder" },
-		FzfLuaTitle = { link = "FloatTitle" },
+		FzfLuaTitle = { link = "FloatBorder" },
 		FzfLuaHeaderBind = { fg = C.yellow },
 		FzfLuaHeaderText = { fg = C.peach },
+		FzfLuaDirPart = { link = "NonText" },
+		FzfLuaFzfMatch = { fg = C.blue },
+		FzfLuaFzfPrompt = { fg = C.blue },
 		FzfLuaPathColNr = { fg = C.blue },
 		FzfLuaPathLineNr = { fg = C.green },
 		FzfLuaBufName = { fg = C.mauve },


### PR DESCRIPTION
The background color doesn't match the border, making it inconsistent. The title is now consistent with telescope too.

Before
![image](https://github.com/user-attachments/assets/947d86c0-7ecb-4110-a9c0-bcaf33d0dc41)

After
![image](https://github.com/user-attachments/assets/5e2c0d0a-cdaa-4ac1-bda0-28d88749868f)
