### PR TITLE
Update mini.indentscope

### DIFF
--- a/lua/catppuccin/groups/integrations/mini.lua
+++ b/lua/catppuccin/groups/integrations/mini.lua
@@ -68,7 +68,6 @@ function M.get()
 		MiniIconsYellow = { fg = C.yellow },
 
 		MiniIndentscopeSymbol = { fg = C[indentscope_color] or C.text },
-		MiniIndentscopePrefix = { style = { "nocombine" } }, -- Make it invisible
 
 		MiniJump = { fg = C.overlay2, bg = C.pink },
 

--- a/lua/catppuccin/groups/integrations/mini.lua
+++ b/lua/catppuccin/groups/integrations/mini.lua
@@ -67,7 +67,7 @@ function M.get()
 		MiniIconsRed = { fg = C.red },
 		MiniIconsYellow = { fg = C.yellow },
 
-		MiniIndentscopeSymbol = { fg = C[indentscope_color] or C.text },
+		MiniIndentscopeSymbol = { fg = C[indentscope_color] or C.overlay2 },
 
 		MiniJump = { fg = C.overlay2, bg = C.pink },
 

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -106,7 +106,7 @@ local M = {
 			},
 			mini = {
 				enabled = true,
-				indentscope_color = "text",
+				indentscope_color = "overlay2",
 			},
 		},
 		color_overrides = {},


### PR DESCRIPTION
Remove a deprecated highlight and use a default which matches with the plugin defaults

Before:

<img width="2032" alt="Screenshot 2025-01-12 at 10 59 49" src="https://github.com/user-attachments/assets/e8421a27-71e1-4f65-8d1c-b9a132684a89" />


After:

<img width="2032" alt="Screenshot 2025-01-12 at 10 59 21" src="https://github.com/user-attachments/assets/9bedbddb-15fb-488c-a2b4-c44a8f9eed67" />

