### PR TITLE
feat: add Avante integration

### DIFF
--- a/lua/catppuccin/groups/integrations/avante.lua
+++ b/lua/catppuccin/groups/integrations/avante.lua
@@ -1,0 +1,57 @@
+local M = {}
+
+function M.get()
+	local rounded = O.integrations.avante.windows_sidebar_header_rounded
+	return {
+		-- titles
+		AvanteTitle = rounded and { bg = C.lavender, fg = C.base } or { fg = C.lavender },
+		AvanteReversedTitle = rounded and { bg = C.none, fg = C.lavender } or { fg = C.lavender },
+
+		AvanteSubtitle = rounded and { bg = C.peach, fg = C.base } or { fg = C.peach },
+		AvanteReversedSubtitle = rounded and { bg = C.none, fg = C.peach } or { fg = C.peach },
+
+		AvanteThirdTitle = rounded and { bg = C.blue, fg = C.base } or { fg = C.blue },
+		AvanteReversedThirdTitle = rounded and { bg = C.none, fg = C.blue } or { fg = C.blue },
+
+		-- hints
+		AvanteInlineHint = { fg = C.overlay0 },
+		AvantePopupHint = { fg = C.overlay0 },
+		AvanteAnnotation = { fg = C.overlay0 },
+		AvanteSuggestion = { fg = C.overlay0 },
+
+		-- conflicts
+		AvanteConflictCurrent = {
+			bg = O.transparent_background and C.none or C.mantle,
+			fg = C.green,
+		},
+		AvanteConflictCurrentLabel = {
+			bg = O.transparent_background and C.none or C.mantle,
+			fg = C.green,
+		},
+
+		AvanteConflictIncoming = {
+			bg = O.transparent_background and C.none or C.mantle,
+			fg = C.blue,
+		},
+		AvanteConflictIncomingLabel = {
+			bg = O.transparent_background and C.none or C.mantle,
+			fg = C.blue,
+		},
+
+		AvanteConflictAncestor = {
+			bg = O.transparent_background and C.none or C.mantle,
+			fg = C.teal,
+		},
+		AvanteConflictAncestorLabel = {
+			bg = O.transparent_background and C.none or C.mantle,
+			fg = C.teal,
+		},
+
+		AvanteToBeDeleted = {
+			bg = O.transparent_background and C.none or C.mantle,
+			fg = C.red,
+		},
+	}
+end
+
+return M

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -105,6 +105,7 @@
 ---@class CtpIntegrations
 ---@field aerial boolean?
 ---@field alpha boolean?
+---@field avante CtpIntegratinAvant | boolean?
 ---@field barbar boolean?
 -- Use this to set it up:
 --
@@ -213,6 +214,11 @@
 ---@field vimwiki boolean?
 ---@field which_key boolean?
 ---@field window_picker boolean?
+
+---@class CtpIntegratinAvant
+--  Whether the opts.windows.sidebar_header.rounded option is set on Avante
+---@field enabled boolean
+---@field windows_sidebar_header_rounded boolean?
 
 ---@class CtpIntegrationBarbecue
 --  Whether to use the alternative background.


### PR DESCRIPTION
Adding support for [avante](https://github.com/yetone/avante.nvim). I'm open to changing what colors are used on the titles, I'm not sure if we have a convention for that.

## Screenshots

Sidebar colors:
![SCR-20250129-laaf](https://github.com/user-attachments/assets/9f770e62-339e-4ec8-97d8-531dbf09da10)

Inline text
![SCR-20250129-labm](https://github.com/user-attachments/assets/31fc1c15-531a-464f-9f75-d1ec7dd9936e)

If rounded is turned off
![SCR-20250129-kxud](https://github.com/user-attachments/assets/532b1a9d-e1fa-4221-b386-7741626e3244)
