### PR TITLE
feat(snacks): add indent highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -1407,9 +1407,11 @@ render_markdown = true
 <td> <a href="https://github.com/folke/snacks.nvim">snacks.nvim</a> </td>
 <td>
 
-
 ```lua
-snacks = false
+snacks = {
+    enabled = false,
+    indent_scope_color = "", -- catppuccin color (eg. `lavender`) Default: text
+}
 ```
 
 </td>

--- a/lua/catppuccin/groups/integrations/snacks.lua
+++ b/lua/catppuccin/groups/integrations/snacks.lua
@@ -1,6 +1,8 @@
 local M = {}
 
 function M.get()
+	local indent_scope_color = O.integrations.snacks.indent_scope_color
+
 	return {
 		SnacksNormal = { link = "NormalFloat" },
 		SnacksWinBar = { link = "Title" },
@@ -45,6 +47,9 @@ function M.get()
 		SnacksDashboardTerminal = { link = "SnacksDashboardNormal" },
 		SnacksDashboardSpecial = { link = "Special" },
 		SnacksDashboardTitle = { link = "Title" },
+
+		SnacksIndent = { fg = C.surface0 },
+		SnacksIndentScope = { fg = C[indent_scope_color] or C.text },
 	}
 end
 

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -200,7 +200,7 @@
 ---@field render_markdown boolean?
 ---@field sandwich boolean?
 ---@field semantic_tokens boolean?
----@field snacks boolean?
+---@field snacks CtpIntegrationSnacks | boolean?
 ---@field symbols_outline boolean?
 ---@field telekasten boolean?
 ---@field telescope CtpIntegrationTelescope | boolean?
@@ -271,6 +271,12 @@
 ---@field enabled boolean
 -- Override the background color for navic.
 ---@field custom_bg CtpColor | "NONE" | "lualine" | nil
+
+---@class CtpIntegrationSnacks
+-- Whether to enable the snacks integration.
+---@field enabled boolean
+-- Sets the color of the indent scope line
+---@field indent_scope_color CtpColor?
 
 ---@class CtpIntegrationTelescope
 -- Whether to enable the telescope integration


### PR DESCRIPTION
This PR adds the `SnacksIndent` and `SnacksIndentScope` highlight groups to the snacks integration.

I mainly just copied the indent-blankline integration for this haha

[Relevant docs from snacks.nvim repo](https://github.com/folke/snacks.nvim/blob/main/docs/indent.md)