### PR TITLE
fix(gitgraph): readme `gitgraph` default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ fzf = true
 <td>
 
 ```lua
-gitgraph = true
+gitgraph = false
 ```
 <!-- gitgraph.nvim -->
 


### PR DESCRIPTION
`girgraph` integration is disabled by default in #822, but `gitgraph = true` in README.md