### PR TITLE
feat(gitgutter): add LineNr highlights

### DIFF
--- a/lua/catppuccin/groups/integrations/gitgutter.lua
+++ b/lua/catppuccin/groups/integrations/gitgutter.lua
@@ -5,6 +5,9 @@ function M.get()
 		GitGutterAdd = { fg = C.green },
 		GitGutterChange = { fg = C.yellow },
 		GitGutterDelete = { fg = C.red },
+		GitGutterAddLineNr = { fg = C.green },
+		GitGutterChangeLineNr = { fg = C.yellow },
+		GitGutterDeleteLineNr = { fg = C.red },
 	}
 end
 


### PR DESCRIPTION
Add [LineNr highlights](https://github.com/airblade/vim-gitgutter?tab=readme-ov-file#line-number-highlights) for the gitgutter integration: 


![image](https://github.com/user-attachments/assets/2ea37401-8f93-4bc1-96b1-57facac2c69d)
