### PR TITLE
fix feline lua syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ ctp_feline.setup({
         extras = clrs.overlay1,
         curr_file = clrs.maroon,
         curr_dir = clrs.flamingo,
-        show_modified = false -- show if the file has been modified
+        show_modified = false, -- show if the file has been modified
         show_lazy_updates = false -- show the count of updatable plugins from lazy.nvim
                                   -- need to set checker.enabled = true in lazy.nvim first
                                   -- the icon is set in ui.icons.plugin in lazy.nvim


### PR DESCRIPTION
it's missing a comma
