### PR TITLE
fix(gitsigns): respect transparent option for gitsigns

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,18 @@ gitgraph = false
 ```lua
 gitsigns = true
 ```
+
+<details> <summary>Special</summary>
+
+```lua
+gitsigns = {
+  enabled = true,
+  -- align with the transparent_background option by default
+  transparent = false,
+}
+ ``` 
+
+</details>
 <!-- gitsigns.nvim -->
 
 <!-- grug-far.nvim -->

--- a/lua/catppuccin/groups/integrations/gitsigns.lua
+++ b/lua/catppuccin/groups/integrations/gitsigns.lua
@@ -1,11 +1,11 @@
 local M = {}
 
 function M.get()
-	if type(O.integrations.gitsigns) == "boolean" then
-		O.integrations.gitsigns = { enabled = true, transparent = false }
-	end
+	-- (a ~= nil) and a or b: Potential false-negative handling
+	local transparent = O.transparent_background
+	if type(O.integrations.gitsigns.transparent) == "boolean" then transparent = O.integrations.gitsigns.transparent end
 
-	if O.transparent_background then
+	if transparent then
 		return {
 			GitSignsAdd = { fg = C.green }, -- diff mode: Added line |diff.txt|
 			GitSignsChange = { fg = C.yellow }, -- diff mode: Changed line |diff.txt|
@@ -13,31 +13,15 @@ function M.get()
 
 			GitSignsCurrentLineBlame = { fg = C.surface1 },
 
-			GitSignsAddPreview = O.integrations.gitsigns.transparent
-					and { fg = U.darken(C.green, 0.72, C.base), bg = C.none }
-				or { link = "DiffAdd" },
-			GitSignsDeletePreview = O.integrations.gitsigns.transparent
-					and { fg = U.darken(C.red, 0.72, C.base), bg = C.none }
-				or { link = "DiffDelete" },
-			-- for word diff in previews
-			GitSignsAddInline = O.integrations.gitsigns.transparent and {
-				fg = C.green,
-				bg = C.none,
-				style = { "bold" },
-			} or { link = "DiffAdd" },
-			GitSignsDeleteInline = O.integrations.gitsigns.transparent and {
-				fg = C.red,
-				bg = C.none,
-				style = { "bold" },
-			} or { link = "DiffDelete" },
-			GitSignsChangeInline = O.integrations.gitsigns.transparent and {
-				fg = C.yellow,
-				bg = C.none,
-				style = { "bold" },
-			} or { link = "DiffChange" },
+			GitSignsAddPreview = { fg = C.green, bg = C.none },
+			GitSignsDeletePreview = { fg = C.red, bg = C.none },
 
-			GitSignsDeleteVirtLn = O.integrations.gitsigns.transparent and { bg = C.none, fg = C.red }
-				or { link = "DiffDelete" },
+			-- for word diff in previews
+			GitSignsAddInline = { fg = C.base, bg = C.green, style = { "bold" } },
+			GitSignsDeleteInline = { fg = C.base, bg = C.red, style = { "bold" } },
+			GitSignsChangeInline = { fg = C.base, bg = C.blue, style = { "bold" } },
+
+			GitSignsDeleteVirtLn = { bg = C.none, fg = C.red },
 		}
 	else
 		return {
@@ -47,12 +31,11 @@ function M.get()
 
 			GitSignsCurrentLineBlame = { fg = C.surface1 },
 
-			GitSignsAddPreview = O.integrations.gitsigns.transparent and { fg = C.green, bg = C.none }
-				or { link = "DiffAdd" },
-			GitSignsDeletePreview = O.integrations.gitsigns.transparent and { fg = C.red, bg = C.none }
-				or { link = "DiffDelete" },
+			GitSignsAddPreview = { link = "DiffAdd" },
+			GitSignsDeletePreview = { link = "DiffDelete" },
 
 			GitSignsAddInline = { bg = U.darken(C.green, 0.36, C.base) },
+			GitSignsChangeInline = { bg = U.darken(C.blue, 0.14, C.base) },
 			GitSignsDeleteInline = { bg = U.darken(C.red, 0.36, C.base) },
 		}
 	end

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -156,7 +156,7 @@
 ---@field fzf boolean?
 ---@field gitgutter boolean?
 ---@field gitgraph boolean?
----@field gitsigns boolean?
+---@field gitsigns CtpIntegrationGitsigns | boolean?
 ---@field grug_far boolean?
 ---@field harpoon boolean?
 ---@field headlines boolean?
@@ -241,6 +241,12 @@
 ---@field enabled boolean
 -- Set to true to apply color to the text in dropbar, false to only apply it to the icons.
 ---@field color_mode boolean?
+
+---@class CtpIntegrationGitsigns
+--- Whether to enable the gitsigns integration
+---@field enabled boolean
+--- Whether to enabled transparent background option
+---@field transparent boolean?
 
 ---@class CtpIntegrationIndentBlankline
 -- Whether to enable the integration.


### PR DESCRIPTION
This PR complements https://github.com/catppuccin/nvim/pull/826

1. Update types.lua and README.md
2. Set `gitsigns.transparent` to align with `transparent_background` by default
3. Optimize certain display effects as shown in the screenshots below

before:
<img width="859" alt="image" src="https://github.com/user-attachments/assets/246b15c8-00f3-475e-adbf-924f2293b03b" />

after:
<img width="896" alt="image" src="https://github.com/user-attachments/assets/91d203d3-4a1b-4f58-a055-4e23a46bec8b" />

Hi @heddxh, this PR should address the issue you mentioned in https://github.com/catppuccin/nvim/pull/826#issuecomment-2692299645. Would you mind testing it?

