### PR TITLE
fix(telescope): nvchad and transparency

### DIFF
--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -13,15 +13,21 @@ function M.get()
 			},
 			TelescopePromptBorder = {
 				fg = O.transparent_background and C.blue or C.surface0,
-				bg = O.transparent_background and C.none or C.surface0,
+				bg = O.transparent_background and O.integrations.telescope.style == "nvchad" and C.surface0
+					or C.none
+					or C.surface0,
 			},
 			TelescopePromptNormal = {
 				fg = C.text,
-				bg = O.transparent_background and C.none or C.surface0,
+				bg = O.transparent_background and O.integrations.telescope.style == "nvchad" and C.surface0
+					or C.none
+					or C.surface0,
 			},
 			TelescopePromptPrefix = {
 				fg = C.flamingo,
-				bg = O.transparent_background and C.none or C.surface0,
+				bg = O.transparent_background and O.integrations.telescope.style == "nvchad" and C.surface0
+					or C.none
+					or C.surface0,
 			},
 			TelescopePreviewTitle = {
 				fg = O.transparent_background and C.green or C.base,

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -4,7 +4,7 @@ function M.get()
 	if O.integrations.telescope.style == "nvchad" then
 		return {
 			TelescopeBorder = {
-				fg = C.blue,
+				fg = C.mantle, -- Match border color with background
 				bg = C.mantle,
 			},
 			TelescopeMatching = { fg = C.blue },
@@ -12,7 +12,7 @@ function M.get()
 				bg = C.mantle,
 			},
 			TelescopePromptBorder = {
-				fg = C.blue,
+				fg = C.surface0, -- Match border color with background
 				bg = C.surface0,
 			},
 			TelescopePromptNormal = {
@@ -45,7 +45,6 @@ function M.get()
 	end
 
 	return {
-		-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
 		TelescopeBorder = { link = "FloatBorder" },
 		TelescopeSelectionCaret = { fg = C.flamingo },
 		TelescopeSelection = {

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -4,46 +4,40 @@ function M.get()
 	if O.integrations.telescope.style == "nvchad" then
 		return {
 			TelescopeBorder = {
-				fg = O.transparent_background and C.blue or C.mantle,
-				bg = O.transparent_background and C.none or C.mantle,
+				fg = C.blue,
+				bg = C.mantle,
 			},
 			TelescopeMatching = { fg = C.blue },
 			TelescopeNormal = {
-				bg = O.transparent_background and C.none or C.mantle,
+				bg = C.mantle,
 			},
 			TelescopePromptBorder = {
-				fg = O.transparent_background and C.blue or C.surface0,
-				bg = O.transparent_background and O.integrations.telescope.style == "nvchad" and C.surface0
-					or C.none
-					or C.surface0,
+				fg = C.blue,
+				bg = C.surface0,
 			},
 			TelescopePromptNormal = {
 				fg = C.text,
-				bg = O.transparent_background and O.integrations.telescope.style == "nvchad" and C.surface0
-					or C.none
-					or C.surface0,
+				bg = C.surface0,
 			},
 			TelescopePromptPrefix = {
 				fg = C.flamingo,
-				bg = O.transparent_background and O.integrations.telescope.style == "nvchad" and C.surface0
-					or C.none
-					or C.surface0,
+				bg = C.surface0,
 			},
 			TelescopePreviewTitle = {
-				fg = O.transparent_background and C.green or C.base,
-				bg = O.transparent_background and C.none or C.green,
+				fg = C.base,
+				bg = C.green,
 			},
 			TelescopePromptTitle = {
-				fg = O.transparent_background and C.red or C.base,
-				bg = O.transparent_background and C.none or C.red,
+				fg = C.base,
+				bg = C.red,
 			},
 			TelescopeResultsTitle = {
-				fg = O.transparent_background and C.lavender or C.mantle,
-				bg = O.transparent_background and C.none or C.lavender,
+				fg = C.mantle,
+				bg = C.lavender,
 			},
 			TelescopeSelection = {
-				fg = O.transparent_background and C.flamingo or C.text,
-				bg = O.transparent_background and C.none or C.surface0,
+				fg = C.text,
+				bg = C.surface0,
 				style = { "bold" },
 			},
 			TelescopeSelectionCaret = { fg = C.flamingo },


### PR DESCRIPTION
Hi, Here is a small fix to basically make it so that if the `telescope.style = "nvchad"` and `transparent_background` = true, then telescope will be opaque and non transparent. I think that if the user explicitly specifies that `telescope.style = "nvchad"` the user would want the telescope window to be opaque.