### PR TITLE
feat(PmenuExtra): add support for PmenuExtra highlights

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -47,6 +47,8 @@ function M.get()
 		PmenuSel = { bg = C.surface1, style = { "bold" } }, -- Popup menu: selected item.
 		PmenuSbar = { bg = C.surface1 }, -- Popup menu: scrollbar.
 		PmenuThumb = { bg = C.overlay0 }, -- Popup menu: Thumb of the scrollbar.
+		PmenuExtra = { fg = C.overlay0 }, -- Popup menu: normal item extra text.
+		PmenuExtraSel = { fg = C.overlay0 }, -- Popup menu: selected item extra text.
 		Question = { fg = C.blue }, -- |hit-enter| prompt and yes/no questions
 		QuickFixLine = { bg = C.surface1, style = { "bold" } }, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
 		Search = { bg = U.darken(C.sky, 0.30, C.base), fg = C.text }, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.


### PR DESCRIPTION
`PmenuExtra` is used for completion item metadata (e.g., completion source).

Use a slightly more muted color than `Pmenu` (e.g., same as `BlinkCmpLabelDeprecated`) to highlight that this metadata is not part of the completion item.

Before (macchiato):
![catppuccin-pmenuextra-before](https://github.com/user-attachments/assets/fd15814e-2397-4ad6-a7c6-cf664116a311)

After (macchiato):
![catppuccin-pmenuextra-after](https://github.com/user-attachments/assets/2e8aaed4-cdbb-44be-a6af-94831fb43d9e)

Other flavors:
- mocha:
  ![catppuccin-mocha-pmenuextra](https://github.com/user-attachments/assets/037b153e-77b1-4a45-9758-0f83256d9625)

- frappe:
  ![catppuccin-frappe-pmenuextra](https://github.com/user-attachments/assets/820e47ee-4480-4a61-839f-18a7b14736dc)

- latte:
  ![catppuccin-latte-pmenuextra](https://github.com/user-attachments/assets/1faa97a0-b605-44c9-b45e-6d3c30e04740)