### PR TITLE
fix(cursor): update cursor color to rosewater / crust

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -4,9 +4,9 @@ function M.get()
 	return {
 		ColorColumn = { bg = C.surface0 }, -- used for the columns set with 'colorcolumn'
 		Conceal = { fg = C.overlay1 }, -- placeholder characters substituted for concealed text (see 'conceallevel')
-		Cursor = { fg = C.base, bg = C.text }, -- character under the cursor
-		lCursor = { fg = C.base, bg = C.text }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
-		CursorIM = { fg = C.base, bg = C.text }, -- like Cursor, but used when in IME mode |CursorIM|
+		Cursor = { fg = C.crust, bg = C.rosewater }, -- character under the cursor
+		lCursor = { fg = C.crust, bg = C.rosewater }, -- the character under the cursor when |language-mapping| is used (see 'guicursor')
+		CursorIM = { fg = C.crust, bg = C.rosewater }, -- like Cursor, but used when in IME mode |CursorIM|
 		CursorColumn = { bg = C.mantle }, -- Screen-column at the cursor, when 'cursorcolumn' is set.
 		CursorLine = {
 			bg = U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),


### PR DESCRIPTION
Follow the style guide at
https://github.com/catppuccin/catppuccin/blob/main/docs/style-guide.md.

Ports for popular terminals follow this style, so nvim, being a primarily terminal app, should strive the same.