### PR TITLE
fix: transparent markdown headings bg

### DIFF
--- a/lua/catppuccin/groups/integrations/markview.lua
+++ b/lua/catppuccin/groups/integrations/markview.lua
@@ -32,7 +32,7 @@ function M.get()
 	}
 
 	local syntax = require("catppuccin.groups.syntax").get()
-	local base = not O.transparent_background and C.base or nil
+	local base = not O.transparent_background and C.base or C.crust
 
 	for i = 0, 7 do
 		local color = rainbow[i] or syntax["rainbow" .. i].fg

--- a/lua/catppuccin/groups/integrations/markview.lua
+++ b/lua/catppuccin/groups/integrations/markview.lua
@@ -32,11 +32,10 @@ function M.get()
 	}
 
 	local syntax = require("catppuccin.groups.syntax").get()
-	local base = not O.transparent_background and C.base or C.crust
 
 	for i = 0, 7 do
 		local color = rainbow[i] or syntax["rainbow" .. i].fg
-		local bg = U.darken(color, darkening_percentage, base)
+		local bg = U.darken(color, darkening_percentage, C.base)
 		groups["MarkviewPalette" .. i] = { fg = color, bg = bg }
 		groups["MarkviewPalette" .. i .. "Fg"] = { fg = color }
 		groups["MarkviewPalette" .. i .. "Bg"] = { bg = bg }

--- a/lua/catppuccin/groups/integrations/markview.lua
+++ b/lua/catppuccin/groups/integrations/markview.lua
@@ -4,7 +4,7 @@ local M = {}
 -- https://github.com/OXY2DEV/markview.nvim#-highlight-groups
 
 function M.get()
-	local darkening_percentage = O.transparent_background and 0.28 or 0.095
+	local darkening_percentage = O.transparent_background and U.vary_color({ latte = 0.15 }, 0.28) or 0.095
 
 	local blockquote_bg = not O.transparent_background and C.mantle or nil
 

--- a/lua/catppuccin/groups/integrations/render_markdown.lua
+++ b/lua/catppuccin/groups/integrations/render_markdown.lua
@@ -18,12 +18,13 @@ function M.get()
 	}
 
 	local syntax = require("catppuccin.groups.syntax").get()
+	local darkening_percentage = O.transparent_background and U.vary_color({ latte = 0.15 }, 0.28) or 0.095
 	local base = not O.transparent_background and C.base or C.crust
 
 	for i = 1, 6 do
 		local color = syntax["rainbow" .. i].fg
 		groups["RenderMarkdownH" .. i] = { fg = color }
-		groups["RenderMarkdownH" .. i .. "Bg"] = { bg = U.darken(color, 0.30, base) }
+		groups["RenderMarkdownH" .. i .. "Bg"] = { bg = U.darken(color, darkening_percentage, base) }
 	end
 
 	return groups

--- a/lua/catppuccin/groups/integrations/render_markdown.lua
+++ b/lua/catppuccin/groups/integrations/render_markdown.lua
@@ -18,7 +18,7 @@ function M.get()
 	}
 
 	local syntax = require("catppuccin.groups.syntax").get()
-	local base = not O.transparent_background and C.base or nil
+	local base = not O.transparent_background and C.base or C.crust
 
 	for i = 1, 6 do
 		local color = syntax["rainbow" .. i].fg

--- a/lua/catppuccin/groups/integrations/render_markdown.lua
+++ b/lua/catppuccin/groups/integrations/render_markdown.lua
@@ -19,12 +19,11 @@ function M.get()
 
 	local syntax = require("catppuccin.groups.syntax").get()
 	local darkening_percentage = O.transparent_background and U.vary_color({ latte = 0.15 }, 0.28) or 0.095
-	local base = not O.transparent_background and C.base or C.crust
 
 	for i = 1, 6 do
 		local color = syntax["rainbow" .. i].fg
 		groups["RenderMarkdownH" .. i] = { fg = color }
-		groups["RenderMarkdownH" .. i .. "Bg"] = { bg = U.darken(color, darkening_percentage, base) }
+		groups["RenderMarkdownH" .. i .. "Bg"] = { bg = U.darken(color, darkening_percentage, C.base) }
 	end
 
 	return groups


### PR DESCRIPTION
use crust as a darkening background for markdown headings with transparent background. previously would fall back to `#000000` (`nil`) which does not work well for latte.

fixes #845 

![before-image](https://github.com/user-attachments/assets/991284e1-78b0-4990-b9a7-d0918e6a0635)
![after-image](https://github.com/user-attachments/assets/390f9e0b-5cbe-4040-b3cd-7b46f3bba9e6)

BEGIN_COMMIT_OVERRIDE
fix(markview): incorrect heading bg when using transparent bg
fix(render-markdown): incorrect heading bg when using transparent bg
END_COMMIT_OVERRIDE
