### PR TITLE
feat(blink-cmp): add `style` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,9 @@ beacon = false
 <td>
 
 ```lua
-blink_cmp = false
+blink_cmp = {
+    border_style = 'bordered',
+}
 ```
 
 </td>

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ beacon = false
 
 ```lua
 blink_cmp = {
-    border_style = 'bordered',
+    style = 'bordered',
 }
 ```
 

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -307,7 +307,7 @@ beacon.nvim>lua
 
 blink.cmp>lua
     blink_cmp = {
-        border_style = 'bordered',
+        style = 'bordered',
     }
 <
 

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -306,7 +306,9 @@ beacon.nvim>lua
 <
 
 blink.cmp>lua
-    blink_cmp = false
+    blink_cmp = {
+        border_style = 'bordered',
+    }
 <
 
 bufferline.nvimSpecial ~

--- a/lua/catppuccin/groups/integrations/blink_cmp.lua
+++ b/lua/catppuccin/groups/integrations/blink_cmp.lua
@@ -43,9 +43,9 @@ function M.get()
 		BlinkCmpKindCopilot = { fg = C.teal },
 	}
 
-	if border_style == 'bordered' then
-		highlights['BlinkCmpMenuBorder'] = { fg = C.blue }
-		highlights['BlinkCmpDocBorder'] = { fg = C.blue }
+	if border_style == "bordered" then
+		highlights["BlinkCmpMenuBorder"] = { fg = C.blue }
+		highlights["BlinkCmpDocBorder"] = { fg = C.blue }
 	end
 
 	return highlights

--- a/lua/catppuccin/groups/integrations/blink_cmp.lua
+++ b/lua/catppuccin/groups/integrations/blink_cmp.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 function M.get()
-	local border_style = O.integrations.blink_cmp.border_style
+	local style = O.integrations.blink_cmp.style
 
 	local highlights = {
 		BlinkCmpLabel = { fg = C.overlay2 },
@@ -43,7 +43,7 @@ function M.get()
 		BlinkCmpKindCopilot = { fg = C.teal },
 	}
 
-	if border_style == "bordered" then
+	if style == "bordered" then
 		highlights["BlinkCmpMenuBorder"] = { fg = C.blue }
 		highlights["BlinkCmpDocBorder"] = { fg = C.blue }
 	end

--- a/lua/catppuccin/groups/integrations/blink_cmp.lua
+++ b/lua/catppuccin/groups/integrations/blink_cmp.lua
@@ -1,12 +1,13 @@
 local M = {}
 
 function M.get()
-	return {
+	local border_style = O.integrations.blink_cmp.border_style
+
+	local highlights = {
 		BlinkCmpLabel = { fg = C.overlay2 },
 		BlinkCmpLabelDeprecated = { fg = C.overlay0, style = { "strikethrough" } },
 		BlinkCmpKind = { fg = C.blue },
 		BlinkCmpMenu = { link = "Pmenu" },
-		BlinkCmpMenuBorder = { fg = C.blue },
 		BlinkCmpLabelMatch = { fg = C.text, style = { "bold" } },
 		BlinkCmpMenuSelection = { bg = C.surface1, style = { "bold" } },
 		BlinkCmpScrollBarGutter = { bg = C.surface1 },
@@ -41,6 +42,13 @@ function M.get()
 		BlinkCmpKindTypeParameter = { fg = C.maroon },
 		BlinkCmpKindCopilot = { fg = C.teal },
 	}
+
+	if border_style == 'bordered' then
+		highlights['BlinkCmpMenuBorder'] = { fg = C.blue }
+		highlights['BlinkCmpDocBorder'] = { fg = C.blue }
+	end
+
+	return highlights
 end
 
 return M

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -121,7 +121,7 @@
 ---```
 ---@field barbecue CtpIntegrationBarbecue | boolean?
 ---@field beacon boolean?
----@field blink_cmp boolean?
+---@field blink_cmp CtpIntegrationsBlinkCmp | boolean?
 ---@field cmp boolean?
 -- `coc.nvim` links to `native_lsp` highlight groups, so you can use
 -- `native_lsp.virtual_text` and `native_lsp.underlines` to style diagnostics.
@@ -231,6 +231,10 @@
 ---@field dim_context boolean?
 -- Whether the directory name should be dimmed.
 ---@field dim_dirname boolean?
+
+---@class CtpIntegrationsBlinkCmp
+--- The border style for the completion menu
+---@field border_style 'solid'|'bordered'
 
 ---@class CtpIntegrationColorfulWinsep
 -- Whether to enable the colorful-winsep integration.

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -234,7 +234,7 @@
 
 ---@class CtpIntegrationsBlinkCmp
 --- The border style for the completion menu
----@field border_style 'solid'|'bordered'
+---@field style 'solid'|'bordered'
 
 ---@class CtpIntegrationColorfulWinsep
 -- Whether to enable the colorful-winsep integration.


### PR DESCRIPTION
adds a `style` to configure whether to use bordered or solid borders. 

can in a future pr be used to add atom-like pmenu styling.

Closes #809 