### PR TITLE
feat: automatic integration detection

### DIFF
--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -197,7 +197,6 @@ function M.setup(user_conf)
 	end
 
 	M.options = vim.tbl_deep_extend("keep", user_conf, M.default_options)
-
 	M.options.highlight_overrides.all = user_conf.custom_highlights or M.options.highlight_overrides.all
 
 	-- Get cached hash

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -37,6 +37,7 @@ local M = {
 			operators = {},
 		},
 		default_integrations = true,
+		auto_integrations = false,
 		integrations = {
 			alpha = true,
 			blink_cmp = true,
@@ -173,10 +174,25 @@ function M.setup(user_conf)
 	-- Parsing user config
 	user_conf = user_conf or {}
 
+	if user_conf.auto_integrations == true then
+		if user_conf.integrations ~= nil then
+			vim.tbl_deep_extend(
+				"keep",
+				user_conf.integrations,
+				require("catppuccin.lib.detect_integrations").create_integrations_table()
+			)
+		else
+			user_conf.integrations = require("catppuccin.lib.detect_integrations").create_integrations_table()
+		end
+	end
+
 	if user_conf.default_integrations == false then M.default_options.integrations = {} end
 
 	M.options = vim.tbl_deep_extend("keep", user_conf, M.default_options)
+
 	M.options.highlight_overrides.all = user_conf.custom_highlights or M.options.highlight_overrides.all
+
+	print(vim.inspect(M.options.integrations))
 
 	-- Get cached hash
 	local cached_path = M.options.compile_path .. M.path_sep .. "cached"

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -192,8 +192,6 @@ function M.setup(user_conf)
 
 	M.options.highlight_overrides.all = user_conf.custom_highlights or M.options.highlight_overrides.all
 
-	print(vim.inspect(M.options.integrations))
-
 	-- Get cached hash
 	local cached_path = M.options.compile_path .. M.path_sep .. "cached"
 	local file = io.open(cached_path)

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -175,15 +175,11 @@ function M.setup(user_conf)
 	user_conf = user_conf or {}
 
 	if user_conf.auto_integrations == true then
-		if user_conf.integrations ~= nil then
-			vim.tbl_deep_extend(
-				"keep",
-				user_conf.integrations,
-				require("catppuccin.lib.detect_integrations").create_integrations_table()
-			)
-		else
-			user_conf.integrations = require("catppuccin.lib.detect_integrations").create_integrations_table()
-		end
+		user_conf.integrations = vim.tbl_deep_extend(
+			"force",
+			require("catppuccin.lib.detect_integrations").create_integrations_table(),
+			user_conf.integrations or {}
+		)
 	end
 
 	if user_conf.default_integrations == false then M.default_options.integrations = {} end

--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -1,0 +1,101 @@
+local M = {}
+
+-- stylua: ignore
+M.integrations = {
+	["aerial.nvim"]											= "aerial",
+	["alpha-nvim"]											= "alpha",
+	["barbar.nvim"]											= "barbar",
+	["barbecue.nvim"]										= "barbecue",
+	["beacon.nvim"]											= "beacon",
+	["blink.cmp"]												= "blink_cmp",
+	["coc.nvim"]												= "coc_nvim",
+	["colorful-winsep.nvim"]						= "colorful_winsep",
+	["dashboard-nvim"]									= "dashboard",
+	["diffview.nvim"]										= "diffview",
+	["dropbar.nvim"]										= "dropbar",
+	["fern.vim"]												= "fern",
+	["fidget.nvim"]											= "fidget",
+	["flash.nvim"]											= "flash",
+	["fzf-lua"]													= "fzf",
+	["gitgraph.nvim"]										= "gitgraph",
+	["gitsigns.nvim"]										= "gitsigns",
+	["grug-fur.nvim"]										= "grug-fur",
+	["harpoon"]													= "harpoon",
+	["headlines.nvim"]									= "headlines",
+	["hop"]															= "hop",
+	["indent-blankline.nvim"]						= "indent_blankline",
+	["leap.nvim"]												= "leap.nvim",
+	["lightspeed.nvim"]									= "lightspeed",
+	["lir.nvim"]												= "lir",
+	["lspsaga"]													= "lsp_saga",
+	["markdown"]												= "markdown",
+	["markview.nvim"]										= "markview",
+	["mason.nvim"]											= "mason",
+	["mini.nvim"]												= "mini",
+	["neo-tree.nvim"]										= "neotree",
+	["neogit"]													= "neogit",
+	["neotest"]													= "neotest",
+	["noice.nvim"]											= "noice",
+	["notifier.nvim"]										= "notifier",
+	["nvim-cmp"]												= "cmp",
+	["copilot_vim"]											= "copilot_vim",
+	["nvim-dap"]												= "dap",
+	["nvim-dap-ui"]											= "dap_ui",
+	["nvim-lspconfig"]									= "native_lsp",
+	["navic"]														= "navic",
+	["nvim-notify"]											= "notify",
+	["nvim-semantic-tokens"]						=	"semantic_tokens",
+	["nvim-surround"]										=	"nvim_surround",
+	["nvim-tree"]												=	"nvimtree",
+	["nvim-treesitter-context"]					= "treesitter_context",
+	["nvim-treesitter"]									= "treesitter",
+	["nvim-ts-rainbow2"]								=	"ts_rainbow2",
+	["nvim-ts-rainbow"]									=	"ts_rainbow",
+	["nvim-ufo"]												=	"ufo",
+	["nvim-window-picker"]							= "window_picker",
+	["octo.nvim"]												= "octo",
+	["overseer.nvim"]										= "overseer",
+	["pounce.nvim"]											= "pounce.nvim",
+	["rainbow-delimiters.nvim"]					= "rainbow_delimiters",
+	["render-markdown.nvim"]						= "render_markdown",
+	["snacks.nvim"]											=	"snacks",
+	["symbols-outline.nvim"]						= "symbols_outline",
+	["telekasten.nvim"]									= "telekasten",
+	["telescope.nvim"]									= "telescope",
+	["trouble.nvim"]										= "lsp_trouble",
+	["vim-dadbod-ui"]										= "dadbod_ui",
+	["vim-gitgutter"]										= "vim-gitgutter",
+	["vim-illuminate"]									= "illuminate",
+	["vim-sandwich"]										= "sandwich",
+	["vim-signify"]											= "signify",
+	["vim-sneak"]												= "vim_sneak",
+	["vimwiki"]													= "vimwiki",
+	["which-key.nvim"]									=	"which_key",
+}
+
+local plugins = {}
+if pcall(require, "lazy") then
+	for plugin, _ in pairs(require("lazy.core.config").plugins) do
+		-- special case for the "mini" library, if one module is present, mark as if the whole library is there.
+		if plugin:match "mini.*" then
+			if not vim.tbl_contains(plugins, "mini.nvim") then table.insert(plugins, "mini.nvim") end
+		else
+			table.insert(plugins, plugin)
+		end
+	end
+end
+
+M.apply = function(integrations_opts)
+	for _, plugin in ipairs(plugins) do
+		if M.integrations[plugin] ~= nil then
+			-- print(plugin .. " - " .. M.integrations[plugin])
+			integrations_opts[M.integrations[plugin]] = true
+		end
+	end
+end
+
+-- testing
+-- M.apply()
+-- print("final_integrations: " .. vim.inspect(final_integrations))
+
+return M

--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -76,7 +76,7 @@ local integration_mappings = {
 local installed_plugins = {}
 if pcall(require, "lazy") then
 	for plugin, _ in pairs(require("lazy.core.config").plugins) do
-		-- special case for the "mini" library, if one module is present, mark as if the whole library is there.
+		-- special case for the "mini" library, if one module is present, mark as if the whole library is installed
 		if plugin:match "mini.*" then
 			if not vim.tbl_contains(installed_plugins, "mini.nvim") then
 				table.insert(installed_plugins, "mini.nvim")
@@ -89,10 +89,16 @@ end
 
 function M.create_integrations_table()
 	local integrations = {}
+	local ctp_defaults = require("catppuccin").default_options.integrations
+
 	for _, plugin in ipairs(installed_plugins) do
 		if integration_mappings[plugin] ~= nil then
 			local integration = integration_mappings[plugin]
-			integrations[integration] = require("catppuccin").default_options.integrations[integration]
+			if type(ctp_defaults[integration]) == "table" then
+				integrations[integration] = ctp_defaults[integration]
+			else
+				integrations[integration] = true
+			end
 		end
 	end
 	return integrations

--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 -- stylua: ignore
-M.integrations = {
+local integration_mappings = {
 	["aerial.nvim"]											= "aerial",
 	["alpha-nvim"]											= "alpha",
 	["barbar.nvim"]											= "barbar",
@@ -73,29 +73,34 @@ M.integrations = {
 	["which-key.nvim"]									=	"which_key",
 }
 
-local plugins = {}
+local installed_plugins = {}
 if pcall(require, "lazy") then
 	for plugin, _ in pairs(require("lazy.core.config").plugins) do
 		-- special case for the "mini" library, if one module is present, mark as if the whole library is there.
 		if plugin:match "mini.*" then
-			if not vim.tbl_contains(plugins, "mini.nvim") then table.insert(plugins, "mini.nvim") end
+			if not vim.tbl_contains(installed_plugins, "mini.nvim") then
+				table.insert(installed_plugins, "mini.nvim")
+			end
 		else
-			table.insert(plugins, plugin)
+			table.insert(installed_plugins, plugin)
 		end
 	end
 end
 
-M.apply = function(integrations_opts)
-	for _, plugin in ipairs(plugins) do
-		if M.integrations[plugin] ~= nil then
+function M.create_integrations_table()
+	local integrations = {}
+	for _, plugin in ipairs(installed_plugins) do
+		if integration_mappings[plugin] ~= nil then
 			-- print(plugin .. " - " .. M.integrations[plugin])
-			integrations_opts[M.integrations[plugin]] = true
+			local integration = integration_mappings[plugin]
+			integrations[integration] = true
 		end
 	end
+	return integrations
 end
 
 -- testing
--- M.apply()
--- print("final_integrations: " .. vim.inspect(final_integrations))
+local integrations = M.create_integrations_table()
+print("detected integrations: " .. vim.inspect(integrations))
 
 return M

--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -22,7 +22,7 @@ local integration_mappings = {
 	["grug-fur.nvim"]										= "grug-fur",
 	["harpoon"]													= "harpoon",
 	["headlines.nvim"]									= "headlines",
-	["hop"]															= "hop",
+	["hop.nvim"]												= "hop",
 	["indent-blankline.nvim"]						= "indent_blankline",
 	["leap.nvim"]												= "leap.nvim",
 	["lightspeed.nvim"]									= "lightspeed",
@@ -91,16 +91,15 @@ function M.create_integrations_table()
 	local integrations = {}
 	for _, plugin in ipairs(installed_plugins) do
 		if integration_mappings[plugin] ~= nil then
-			-- print(plugin .. " - " .. M.integrations[plugin])
 			local integration = integration_mappings[plugin]
-			integrations[integration] = true
+			integrations[integration] = require("catppuccin").default_options.integrations[integration]
 		end
 	end
 	return integrations
 end
 
 -- testing
-local integrations = M.create_integrations_table()
-print("detected integrations: " .. vim.inspect(integrations))
+-- local integrations = M.create_integrations_table()
+-- print("detected integrations: " .. vim.inspect(integrations))
 
 return M

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -33,6 +33,8 @@
 ---@field styles CtpStyles?
 -- Should default integrations be used.
 ---@field default_integrations boolean?
+---@field auto_integrations boolean?
+-- Should detect integrations automatically?
 -- Toggle integrations. Integrations allow Catppuccin to set the theme of various plugins.
 ---@field integrations CtpIntegrations?
 -- Catppuccin colors can be overwritten here.

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -33,8 +33,8 @@
 ---@field styles CtpStyles?
 -- Should default integrations be used.
 ---@field default_integrations boolean?
----@field auto_integrations boolean?
 -- Should detect integrations automatically
+---@field auto_integrations boolean?
 -- Toggle integrations. Integrations allow Catppuccin to set the theme of various plugins.
 ---@field integrations CtpIntegrations?
 -- Catppuccin colors can be overwritten here.

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -34,7 +34,7 @@
 -- Should default integrations be used.
 ---@field default_integrations boolean?
 ---@field auto_integrations boolean?
--- Should detect integrations automatically?
+-- Should detect integrations automatically
 -- Toggle integrations. Integrations allow Catppuccin to set the theme of various plugins.
 ---@field integrations CtpIntegrations?
 -- Catppuccin colors can be overwritten here.


### PR DESCRIPTION
closes #838 

detects installed plugins and creates a matching integrations table.
currently only plugins installed with [lazy.nvim](https://github.com/folke/lazy.nvim) are detected.

I need to check how to populate the config's integrations table with the generated one and provide an option for it.

I would like to get some comments on the location in the code base.
any other feedback is also appreciated!
