### PR TITLE
fix(snacks): fix snacks_picker weird border color

### DIFF
--- a/lua/catppuccin/groups/integrations/snacks.lua
+++ b/lua/catppuccin/groups/integrations/snacks.lua
@@ -52,9 +52,11 @@ function M.get()
 		SnacksIndentScope = { fg = C[indent_scope_color] or C.text },
 
 		SnacksPicker = { link = "NormalFloat" },
-		SnacksPickerInputBorder = { link = "SnacksPickerBorder" },
-
-		SnacksPickerBorder = { link = "FloatBorder" },
+		SnacksPickerInputBorder = { fg = C.blue, bg = C.mantle },
+		SnacksPickerInputTitle = { fg = C.blue, bg = C.mantle },
+		SnacksPickerBoxTitle = { fg = C.blue, bg = C.mantle },
+		SnacksPickerPreviewTitle = { fg = C.blue, bg = C.mantle },
+		SnacksPickerBorder = { fg = C.blue, bg = C.mantle },
 		SnacksPickerSelected = {
 			fg = O.transparent_background and C.flamingo or C.text,
 			bg = O.transparent_background and C.none or C.surface0,


### PR DESCRIPTION
Fixed weird border color with `snacks_picker`

**BEFORE:**
![Screenshot 2025-06-26 150730](https://github.com/user-attachments/assets/bd2fcbbc-7937-4435-a8e7-bb34339a19aa)

**AFTER:**
![Screenshot 2025-06-26 154655](https://github.com/user-attachments/assets/0a644d1c-cfa8-4507-aa0c-ba31aaceb459)
