### PR TITLE
feat: make bg of `FloatBorder` same as `NormalFloat`

### DIFF
--- a/README.md
+++ b/README.md
@@ -774,7 +774,7 @@ gitsigns = {
   -- align with the transparent_background option by default
   transparent = false,
 }
- ``` 
+ ```
 
 </details>
 <!-- gitsigns.nvim -->
@@ -1497,7 +1497,7 @@ telekasten = false
 ```lua
 telescope = {
     enabled = true,
-    -- style = "nvchad"
+    -- style = "classic", "nvchad" or "nvchad_outlined"
 }
 ```
 

--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -38,7 +38,7 @@ function M.get()
 		}, -- normal text in non-current windows
 		NormalSB = { fg = C.text, bg = C.crust }, -- normal text in non-current windows
 		NormalFloat = { fg = C.text, bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle }, -- Normal text in floating windows.
-		FloatBorder = { fg = C.blue },
+		FloatBorder = { fg = C.blue, bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle },
 		FloatTitle = { fg = C.subtext0 }, -- Title of floating windows
 		Pmenu = {
 			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or U.darken(C.surface0, 0.8, C.crust),

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -4,40 +4,81 @@ function M.get()
 	if O.integrations.telescope.style == "nvchad" then
 		return {
 			TelescopeBorder = {
-				fg = O.transparent_background and C.blue or C.mantle,
-				bg = O.transparent_background and C.none or C.mantle,
+				fg = C.mantle,
+				bg = C.mantle,
 			},
 			TelescopeMatching = { fg = C.blue },
 			TelescopeNormal = {
-				bg = O.transparent_background and C.none or C.mantle,
+				bg = C.mantle,
 			},
 			TelescopePromptBorder = {
-				fg = O.transparent_background and C.blue or C.surface0,
-				bg = O.transparent_background and C.none or C.surface0,
+				fg = C.surface0,
+				bg = C.surface0,
 			},
 			TelescopePromptNormal = {
 				fg = C.text,
-				bg = O.transparent_background and C.none or C.surface0,
+				bg = C.surface0,
 			},
 			TelescopePromptPrefix = {
 				fg = C.flamingo,
-				bg = O.transparent_background and C.none or C.surface0,
+				bg = C.surface0,
 			},
 			TelescopePreviewTitle = {
-				fg = O.transparent_background and C.green or C.base,
-				bg = O.transparent_background and C.none or C.green,
+				fg = C.base,
+				bg = C.green,
 			},
 			TelescopePromptTitle = {
-				fg = O.transparent_background and C.red or C.base,
-				bg = O.transparent_background and C.none or C.red,
+				fg = C.base,
+				bg = C.red,
 			},
 			TelescopeResultsTitle = {
-				fg = O.transparent_background and C.lavender or C.mantle,
-				bg = O.transparent_background and C.none or C.lavender,
+				fg = C.mantle,
+				bg = C.lavender,
 			},
 			TelescopeSelection = {
-				fg = O.transparent_background and C.flamingo or C.text,
-				bg = O.transparent_background and C.none or C.surface0,
+				fg = C.text,
+				bg = C.surface0,
+				style = { "bold" },
+			},
+			TelescopeSelectionCaret = { fg = C.flamingo },
+		}
+	elseif O.integrations.telescope.style == "nvchad_outlined" then
+		return {
+			TelescopeBorder = {
+				fg = C.surface2,
+				bg = C.none,
+			},
+			TelescopeMatching = { fg = C.blue },
+			TelescopeNormal = {
+				bg = C.none,
+			},
+			TelescopePromptBorder = {
+				fg = C.surface2,
+				bg = C.none,
+			},
+			TelescopePromptNormal = {
+				fg = C.text,
+				bg = C.none,
+			},
+			TelescopePromptPrefix = {
+				fg = C.flamingo,
+				bg = C.none,
+			},
+			TelescopePreviewTitle = {
+				fg = C.base,
+				bg = C.green,
+			},
+			TelescopePromptTitle = {
+				fg = C.base,
+				bg = C.red,
+			},
+			TelescopeResultsTitle = {
+				fg = C.mantle,
+				bg = C.lavender,
+			},
+			TelescopeSelection = {
+				fg = C.text,
+				bg = C.surface0,
 				style = { "bold" },
 			},
 			TelescopeSelectionCaret = { fg = C.flamingo },
@@ -45,7 +86,7 @@ function M.get()
 	end
 
 	return {
-		-- TelescopeNormal = { link = "NormalFloat" }, -- Respect telescope's default float bg
+		TelescopeNormal = { link = "NormalFloat" },
 		TelescopeBorder = { link = "FloatBorder" },
 		TelescopeSelectionCaret = { fg = C.flamingo },
 		TelescopeSelection = {

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -304,7 +304,7 @@
 -- Whether to enable the telescope integration
 ---@field enabled boolean?
 -- The style of Telescope
----@field style "classic" | "nvchad" | nil
+---@field style "classic" | "nvchad" | "nvchad_outlined" | nil
 
 ---@class CtpIntegrationIlluminate
 -- Whether to enable the vim-illuminate integration


### PR DESCRIPTION
feat(telescope): add `nvchad_outlined` style

dup #847 #874 

@Lalit64 @Atifchy Please check if this PR works for you.

- `1`: doesn't look different before/after
- `2`: doesn't look different whether `transparent_background` is `true` or `false`
- solid: `transparent_background = false`
- transparent: `transparent_background = true`

Single border windows:

| * | before | after |
| --- | --- | --- |
| transparent (`1`) |  |  |
| solid | <img width="958" height="633" alt="Sway_20250722_20h29m40s" src="https://github.com/user-attachments/assets/83c54cef-5231-44fe-853a-3663a9d02cfb" /> | <img width="958" height="633" alt="Sway_20250722_20h29m28s" src="https://github.com/user-attachments/assets/1d715388-0996-4ea4-b3b7-767c627e8887" /> |

`telescope.nvim`:

| * | before | after |
| --- | --- | --- |
| transparent `classic` (`1`) |  |  |
| solid `classic` (`1`) |  |  |
| transparent `nvchad` | <img width="1503" height="883" alt="Sway_20250722_20h38m04s" src="https://github.com/user-attachments/assets/244112e1-3870-4067-967d-c114ac31aa6d" /> | <img width="1503" height="883" alt="Sway_20250722_20h38m17s" src="https://github.com/user-attachments/assets/3d583e97-466c-48ee-bf7a-76c6ef2bafb3" /> |
| solid `nvchad` (`1`) |  |  |
| `nvchad_outlined` (`2`) |  | <img width="1503" height="883" alt="Sway_20250722_20h35m11s" src="https://github.com/user-attachments/assets/65c0b832-20b9-47aa-8122-503e5ab09185" /> |




