### PR TITLE
fix(fzf): fix FzfLuaBorder bg color

### DIFF
--- a/lua/catppuccin/groups/integrations/fzf.lua
+++ b/lua/catppuccin/groups/integrations/fzf.lua
@@ -2,9 +2,10 @@ local M = {}
 
 function M.get()
 	return {
-		-- FzfLuaNormal = { link = "NormalFloat" }, Respect fzf-lua's default float bg
-		FzfLuaBorder = { link = "FloatBorder" },
-		FzfLuaTitle = { link = "FloatBorder" },
+		-- Respect fzf-lua's default float bg. Do not set `bg` or link to a group that sets `bg`.
+		-- FzfLuaNormal = { link = "NormalFloat" },
+		FzfLuaBorder = { fg = C.blue }, -- Match `FloatBorder` `fg`
+		FzfLuaTitle = { fg = C.blue }, -- Match `FzfLuaBorder` `fg`
 		FzfLuaHeaderBind = { fg = C.yellow },
 		FzfLuaHeaderText = { fg = C.peach },
 		FzfLuaDirPart = { link = "NonText" },


### PR DESCRIPTION
With https://github.com/catppuccin/nvim/pull/877, the fzf-lua float bg color is overridden for borders, which leads to an inconsistent theming.

Before:
<img width="1198" height="743" alt="catppuccin-fzf-before" src="https://github.com/user-attachments/assets/332507c2-9a82-49d1-b9a8-5cd65f3addd2" />

After:
<img width="1198" height="743" alt="catppuccin-fzf-after" src="https://github.com/user-attachments/assets/5c9aa81a-be54-4452-9e65-a37fd4f16f71" />
