### PR TITLE
fix(editor): link `FloatTitle` bg to `NormalFloat`

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -39,7 +39,7 @@ function M.get()
 		NormalSB = { fg = C.text, bg = C.crust }, -- normal text in non-current windows
 		NormalFloat = { fg = C.text, bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle }, -- Normal text in floating windows.
 		FloatBorder = { fg = C.blue, bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle },
-		FloatTitle = { fg = C.subtext0 }, -- Title of floating windows
+		FloatTitle = { fg = C.subtext0, bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle }, -- Title of floating windows
 		Pmenu = {
 			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or U.darken(C.surface0, 0.8, C.crust),
 			fg = C.overlay2,


### PR DESCRIPTION
we should probably link the bg of FloatTitle to NormalFloat since these titles always (in classic style) need the same bg as the floating window. This will help make most of the floating windows look a bit more consistant without integrations.

replaces #879