### PR TITLE
fix(fzf): link normal and border to defaults

### DIFF
--- a/lua/catppuccin/groups/integrations/fzf.lua
+++ b/lua/catppuccin/groups/integrations/fzf.lua
@@ -2,9 +2,9 @@ local M = {}
 
 function M.get()
 	return {
-		-- FzfLuaNormal = { link = "NormalFloat" }, Respect fzf-lua's default float bg
+		FzfLuaNormal = { link = "NormalFloat" },
 		FzfLuaBorder = { link = "FloatBorder" },
-		FzfLuaTitle = { link = "FloatBorder" },
+		FzfLuaTitle = { link = "FloatTitle" },
 		FzfLuaHeaderBind = { fg = C.yellow },
 		FzfLuaHeaderText = { fg = C.peach },
 		FzfLuaDirPart = { link = "NonText" },


### PR DESCRIPTION
depends on #882 

just uses the default float hlgroups for the fzf window

replaces #879