### PR TITLE
feat!: add global floating window options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ require("catppuccin").setup({
         dark = "mocha",
     },
     transparent_background = false, -- disables setting the background color.
+    float = {
+        transparent = false, -- enables transparency on floating windows
+        solid = false, -- use nvchad styling for floating windows
+    },
     show_end_of_buffer = false, -- shows the '~' characters after the end of buffers
     term_colors = false, -- sets terminal colors (e.g. `g:terminal_color_0`)
     dim_inactive = {
@@ -1450,7 +1454,6 @@ render_markdown = true
 snacks = {
     enabled = false,
     indent_scope_color = "", -- catppuccin color (eg. `lavender`) Default: text
-    -- picker_style = "classic", "nvchad" or "nvchad_outlined",
 }
 ```
 
@@ -1498,7 +1501,6 @@ telekasten = false
 ```lua
 telescope = {
     enabled = true,
-    -- style = "classic", "nvchad" or "nvchad_outlined"
 }
 ```
 

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -74,6 +74,10 @@ options and settings.
             dark = "mocha",
         },
         transparent_background = false, -- disables setting the background color.
+        float = {
+            transparent = false, -- enables transparency on floating windows
+            solid = false, -- use nvchad styling for floating windows
+        },
         show_end_of_buffer = false, -- shows the '~' characters after the end of buffers
         term_colors = false, -- sets terminal colors (e.g. `g:terminal_color_0`)
         dim_inactive = {
@@ -841,7 +845,6 @@ snacks.nvim>lua
     snacks = {
         enabled = false,
         indent_scope_color = "", -- catppuccin color (eg. `lavender`) Default: text
-        -- picker_style = "classic", "nvchad" or "nvchad_outlined",
     }
 <
 
@@ -859,7 +862,6 @@ telekasten.nvim>lua
 telescope.nvim>lua
     telescope = {
         enabled = true,
-        -- style = "classic", "nvchad" or "nvchad_outlined"
     }
 <
 

--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -37,9 +37,18 @@ function M.get()
 				or C.base,
 		}, -- normal text in non-current windows
 		NormalSB = { fg = C.text, bg = C.crust }, -- normal text in non-current windows
-		NormalFloat = { fg = C.text, bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle }, -- Normal text in floating windows.
-		FloatBorder = { fg = C.blue, bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle },
-		FloatTitle = { fg = C.subtext0, bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle }, -- Title of floating windows
+		NormalFloat = { fg = C.text, bg = (O.float.transparent and vim.o.winblend == 0) and C.none or C.mantle }, -- Normal text in floating windows.
+		FloatBorder = O.float.solid
+				and ((O.float.transparent and vim.o.winblend == 0) and { fg = C.blue, bg = C.none } or {
+					fg = C.mantle,
+					bg = C.mantle,
+				})
+			or { fg = C.blue, bg = (O.float.transparent and vim.o.winblend == 0) and C.none or C.mantle },
+		FloatTitle = O.float.solid and {
+			fg = C.crust,
+			bg = C.lavender,
+		} or { fg = C.subtext0, bg = (O.float.transparent and vim.o.winblend == 0) and C.none or C.mantle }, -- Title of floating windows
+		FloatShadow = { fg = (O.float.transparent and vim.o.winblend == 0) and C.none or C.overlay0 },
 		Pmenu = {
 			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or U.darken(C.surface0, 0.8, C.crust),
 			fg = C.overlay2,

--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -39,7 +39,7 @@ function M.get()
 		NormalSB = { fg = C.text, bg = C.crust }, -- normal text in non-current windows
 		NormalFloat = { fg = C.text, bg = (O.float.transparent and vim.o.winblend == 0) and C.none or C.mantle }, -- Normal text in floating windows.
 		FloatBorder = O.float.solid
-				and ((O.float.transparent and vim.o.winblend == 0) and { fg = C.blue, bg = C.none } or {
+				and ((O.float.transparent and vim.o.winblend == 0) and { fg = C.surface2, bg = C.none } or {
 					fg = C.mantle,
 					bg = C.mantle,
 				})

--- a/lua/catppuccin/groups/integrations/mini.lua
+++ b/lua/catppuccin/groups/integrations/mini.lua
@@ -50,7 +50,14 @@ function M.get()
 		MiniFilesFile = { fg = C.text },
 		MiniFilesNormal = { link = "NormalFloat" },
 		MiniFilesTitle = { link = "FloatTitle" },
-		MiniFilesTitleFocused = { fg = C.subtext0, style = { "bold" } },
+		MiniFilesTitleFocused = O.float.solid and {
+			fg = C.crust,
+			bg = C.mauve,
+		} or {
+			fg = C.subtext0,
+			bg = (O.float.transparent and vim.o.winblend == 0) and C.none or C.mantle,
+			style = { "bold" },
+		},
 
 		MiniHipatternsFixme = { fg = C.base, bg = C.red, style = { "bold" } },
 		MiniHipatternsHack = { fg = C.base, bg = C.yellow, style = { "bold" } },

--- a/lua/catppuccin/groups/integrations/mini.lua
+++ b/lua/catppuccin/groups/integrations/mini.lua
@@ -98,7 +98,7 @@ function M.get()
 		MiniPickBorderBusy = { link = "DiagnosticFloatingWarn" },
 		MiniPickBorderText = {
 			fg = C.mauve,
-			bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle,
+			bg = O.float.transparent and C.none or C.mantle,
 		},
 		MiniPickIconDirectory = { link = "Directory" },
 		MiniPickIconFile = { link = "MiniPickNormal" },
@@ -113,14 +113,14 @@ function M.get()
 		MiniPickNormal = { link = "NormalFloat" },
 		MiniPickPreviewLine = { link = "CursorLine" },
 		MiniPickPreviewRegion = { link = "IncSearch" },
-		MiniPickPrompt = { fg = C.text, bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle },
+		MiniPickPrompt = { fg = C.text, bg = O.float.transparent and C.none or C.mantle },
 		MiniPickPromptCaret = {
 			fg = C.flamingo,
-			bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle,
+			bg = O.float.transparent and C.none or C.mantle,
 		},
 		MiniPickPromptPrefix = {
 			fg = C.flamingo,
-			bg = (O.transparent_background and vim.o.winblend == 0) and C.none or C.mantle,
+			bg = O.float.transparent and C.none or C.mantle,
 		},
 
 		MiniStarterCurrent = {},

--- a/lua/catppuccin/groups/integrations/snacks.lua
+++ b/lua/catppuccin/groups/integrations/snacks.lua
@@ -1,52 +1,12 @@
 local M = {}
 
--- only applicable with `picker_style = "nvchad" or "nvchad_outlined"`
--- ```lua
--- require("snacks").setup({
---   picker = {
---     layout = {
---       layout = require("catppuccin.groups.integrations.snacks").get_layout(),
---     },
---   },
--- })
--- ```
-function M.get_layout()
-	return {
-		box = "horizontal",
-		border = "none",
-		{
-			box = "vertical",
-			{
-				win = "input",
-				title = " {source} {live} ",
-				title_pos = "center",
-				border = "solid",
-				height = 1,
-			},
-			{
-				win = "list",
-				title = "  Results  ",
-				title_pos = "center",
-				border = "solid",
-			},
-		},
-		{
-			win = "preview",
-			width = 0.45,
-			title_pos = "center",
-		},
-	}
-end
-
 function M.get()
 	local indent_scope_color = O.integrations.snacks.indent_scope_color
-	local picker_style = O.integrations.snacks.picker_style
-	local nvchad_style = picker_style == "nvchad" or picker_style == "nvchad_outlined"
 
 	local hlgroups = {
 		SnacksNormal = { link = "NormalFloat" },
 		SnacksWinBar = { link = "Title" },
-		SnacksBackdrop = { fg = C.overlay0 },
+		SnacksBackdrop = { link = "FloatShadow" },
 		SnacksNormalNC = { link = "NormalFloat" },
 		SnacksWinBarNC = { link = "SnacksWinBar" },
 
@@ -92,33 +52,20 @@ function M.get()
 		SnacksIndentScope = { fg = C[indent_scope_color] or C.text },
 
 		SnacksPickerSelected = {
-			fg = O.transparent_background and C.flamingo or C.text,
-			bg = O.transparent_background and C.none or C.surface0,
+			fg = O.float.transparent and C.flamingo or C.text,
+			bg = O.float.transparent and C.none or C.surface0,
 			style = { "bold" },
 		},
 		SnacksPickerMatch = { fg = C.blue },
+
+		SnacksPicker = { link = "NormalFloat" },
+		SnacksPickerBorder = { link = "FloatBorder" },
+		SnacksPickerInputBorder = { link = "SnacksPickerBorder" },
+		SnacksPickerInput = { link = "NormalFloat" },
+		SnacksPickerPrompt = { fg = C.flamingo },
 	}
 
-	if nvchad_style then
-		hlgroups["SnacksPicker"] = {
-			bg = C.mantle,
-		}
-		hlgroups["SnacksPickerBorder"] = {
-			fg = C.mantle,
-			bg = C.mantle,
-		}
-		hlgroups["SnacksPickerInputBorder"] = {
-			fg = C.mantle,
-			bg = C.mantle,
-		}
-		hlgroups["SnacksPickerInput"] = {
-			fg = C.text,
-			bg = C.mantle,
-		}
-		hlgroups["SnacksPickerPrompt"] = {
-			fg = C.flamingo,
-			bg = C.none,
-		}
+	if O.float.solid then
 		hlgroups["SnacksPickerTitle"] = {
 			fg = C.crust,
 			bg = C.mauve,
@@ -134,36 +81,6 @@ function M.get()
 		hlgroups["SnacksPickerListTitle"] = {
 			fg = C.crust,
 			bg = C.lavender,
-		}
-
-		if picker_style == "nvchad_outlined" then
-			hlgroups["SnacksPicker"] = {
-				bg = C.none,
-			}
-			hlgroups["SnacksPickerBorder"] = {
-				fg = C.surface2,
-				bg = C.none,
-			}
-			hlgroups["SnacksPickerInputBorder"] = {
-				fg = C.surface2,
-				bg = C.none,
-			}
-			hlgroups["SnacksPickerInput"] = {
-				fg = C.text,
-				bg = C.none,
-			}
-		end
-	else
-		hlgroups["SnacksPicker"] = { link = "NormalFloat" }
-		hlgroups["SnacksPickerBorder"] = { link = "FloatBorder" }
-		hlgroups["SnacksPickerInputBorder"] = { link = "SnacksPickerBorder" }
-		hlgroups["SnacksPickerInput"] = {
-			fg = C.text,
-			bg = C.none,
-		}
-		hlgroups["SnacksPickerPrompt"] = {
-			fg = C.flamingo,
-			bg = C.none,
 		}
 	end
 

--- a/lua/catppuccin/groups/integrations/telescope.lua
+++ b/lua/catppuccin/groups/integrations/telescope.lua
@@ -1,101 +1,39 @@
 local M = {}
 
 function M.get()
-	if O.integrations.telescope.style == "nvchad" then
-		return {
-			TelescopeBorder = {
-				fg = C.mantle,
-				bg = C.mantle,
-			},
-			TelescopeMatching = { fg = C.blue },
-			TelescopeNormal = {
-				bg = C.mantle,
-			},
-			TelescopePromptBorder = {
-				fg = C.surface0,
-				bg = C.surface0,
-			},
-			TelescopePromptNormal = {
-				fg = C.text,
-				bg = C.surface0,
-			},
-			TelescopePromptPrefix = {
-				fg = C.flamingo,
-				bg = C.surface0,
-			},
-			TelescopePreviewTitle = {
-				fg = C.base,
-				bg = C.green,
-			},
-			TelescopePromptTitle = {
-				fg = C.base,
-				bg = C.red,
-			},
-			TelescopeResultsTitle = {
-				fg = C.mantle,
-				bg = C.lavender,
-			},
-			TelescopeSelection = {
-				fg = C.text,
-				bg = C.surface0,
-				style = { "bold" },
-			},
-			TelescopeSelectionCaret = { fg = C.flamingo },
-		}
-	elseif O.integrations.telescope.style == "nvchad_outlined" then
-		return {
-			TelescopeBorder = {
-				fg = C.surface2,
-				bg = C.none,
-			},
-			TelescopeMatching = { fg = C.blue },
-			TelescopeNormal = {
-				bg = C.none,
-			},
-			TelescopePromptBorder = {
-				fg = C.surface2,
-				bg = C.none,
-			},
-			TelescopePromptNormal = {
-				fg = C.text,
-				bg = C.none,
-			},
-			TelescopePromptPrefix = {
-				fg = C.flamingo,
-				bg = C.none,
-			},
-			TelescopePreviewTitle = {
-				fg = C.base,
-				bg = C.green,
-			},
-			TelescopePromptTitle = {
-				fg = C.base,
-				bg = C.red,
-			},
-			TelescopeResultsTitle = {
-				fg = C.mantle,
-				bg = C.lavender,
-			},
-			TelescopeSelection = {
-				fg = C.text,
-				bg = C.surface0,
-				style = { "bold" },
-			},
-			TelescopeSelectionCaret = { fg = C.flamingo },
-		}
-	end
-
-	return {
-		TelescopeNormal = { link = "NormalFloat" },
+	local hlgroups = {
 		TelescopeBorder = { link = "FloatBorder" },
-		TelescopeSelectionCaret = { fg = C.flamingo },
+		TelescopeNormal = { link = "NormalFloat" },
+		TelescopePreviewNormal = { link = "TelescopeNormal" },
+		TelescopePromptNormal = { link = "TelescopeNormal" },
+		TelescopeResultsNormal = { link = "TelescopeNormal" },
+		TelescopeTitle = { link = "FloatTitle" },
+		TelescopeSelectionCaret = { fg = C.flamingo, bg = C.surface0 },
 		TelescopeSelection = {
-			fg = O.transparent_background and C.flamingo or C.text,
-			bg = O.transparent_background and C.none or C.surface0,
+			fg = C.flamingo,
+			bg = C.surface0,
 			style = { "bold" },
 		},
 		TelescopeMatching = { fg = C.blue },
+		TelescopePromptPrefix = { fg = C.flamingo },
 	}
+
+	if O.float.solid then
+		hlgroups["TelescopePreviewTitle"] = {
+			fg = C.crust,
+			bg = C.green,
+		}
+		hlgroups["TelescopePromptTitle"] = {
+			fg = C.crust,
+			bg = C.red,
+		}
+		hlgroups["TelescopeResultsTitle"] = {
+			fg = C.crust,
+			bg = C.lavender,
+		}
+	end
+
+	return hlgroups
 end
 
 return M

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -11,6 +11,10 @@ local M = {
 		},
 		compile_path = vim.fn.stdpath "cache" .. "/catppuccin",
 		transparent_background = false,
+		float = {
+			transparent = false,
+			solid = false,
+		},
 		show_end_of_buffer = false,
 		term_colors = false,
 		kitty = vim.env.KITTY_WINDOW_ID and true or false,

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -15,6 +15,7 @@
 ---@field compile_path string?
 -- Whether to enable transparency.
 ---@field transparent_background boolean?
+---@field float CtpFloatOpts
 -- Toggle the `~` characters after the end of buffers.
 ---@field show_end_of_buffer boolean?
 -- If true, sets terminal colors (e.g. `g:terminal_color_0`).
@@ -51,6 +52,10 @@
 ---@field dark CtpFlavor?
 -- Catppuccin flavor to use when `:set background=light` is set.
 ---@field light CtpFlavor?
+
+---@class CtpFloatOpts
+---@field transparent boolean transparency should follow `transparent_background`
+---@field solid boolean use nvchad style floating windows
 
 ---@class CtpDimInactive
 -- Whether to dim inactive windows.
@@ -299,14 +304,10 @@
 ---@field enabled boolean
 -- Sets the color of the indent scope line
 ---@field indent_scope_color CtpColor?
--- The style of Snacks.picker
----@field picker_style "classic" | "nvchad" | "nvchad_outlined" | nil
 
 ---@class CtpIntegrationTelescope
 -- Whether to enable the telescope integration
 ---@field enabled boolean?
--- The style of Telescope
----@field style "classic" | "nvchad" | "nvchad_outlined" | nil
 
 ---@class CtpIntegrationIlluminate
 -- Whether to enable the vim-illuminate integration


### PR DESCRIPTION
fixes #856

based on the work started in #877

putting all the floating window options, that were previously in integration opts, globally so its clear what integrations should provide in customization:
```lua
-- config:
{
  float = {
    transparent = false, -- whether floating windows should be transparent
    solid = false, -- whether to use nvchad (solid) style or classic style floats
  },
}
```

in the current implementation i would get the following results for `transparent_background = true`:
trans bg + trans float + classic float = outlined
trans bg + opague float + solid float = nvchad
trans bg + trans float + solid float = nvchad outlined