### PR TITLE
fix: make sure to enable auto detected integrations with table configurations

### DIFF
--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -97,6 +97,7 @@ function M.create_integrations_table()
 			local integration = integration_mappings[plugin]
 			if type(ctp_defaults[integration]) == "table" then
 				integrations[integration] = ctp_defaults[integration]
+				integrations[integration].enabled = true
 			else
 				integrations[integration] = true
 			end


### PR DESCRIPTION
The new auto integration detection is great! I noticed in some cases it doesn't enable the integration unless I manually put `enabled = true` in the integrations table. I dug into this and it appears it's missing the portion that sets `enabled = true` for table based integration configuration.

The example I ran into this with was setting up custom configuration for `snacks = { picker_style = "nvchad" }` in my integrations table and the snacks integration is not properly enabled when I start the editor. It simply needs `enabled = true` enabled. This will also be the case for something like `colorful_winsep` or `navic` where the default configuration has `enabled = false`