### PR TITLE
fix: add missing table based integrations to fix auto integration detection

### DIFF
--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -40,7 +40,7 @@ local M = {
 		auto_integrations = false,
 		integrations = {
 			alpha = true,
-			blink_cmp = true,
+			blink_cmp = { enabled = true, style = "bordered" },
 			fzf = true,
 			cmp = true,
 			dap = true,
@@ -111,6 +111,11 @@ local M = {
 				enabled = true,
 				indentscope_color = "overlay2",
 			},
+			lir = {
+				enabled = false,
+				git_status = false,
+			},
+			snacks = { enabled = false },
 		},
 		color_overrides = {},
 		highlight_overrides = {},


### PR DESCRIPTION
Based on how the auto integration is done, plugins with table based configuration are required to have them specified in the default integration list to actually make auto integration detection work if the user has done any sort of customization to the integrations.

For example if the `snacks` is set to `{ picker_style = "nvchad" }` then without this change the auto integration detection doesn't work. This is because the auto detection would set `snacks = true` and then would not merge properly with the user configuration table, so the result is just `{ picker_style = "nvchad" }` rather than `{ enabled = true, picker_style = "nvchad" }`

This is a follow on to #886 