### PR TITLE
fix(snacks): fix snacks picker input field color

### DIFF
--- a/lua/catppuccin/groups/integrations/snacks.lua
+++ b/lua/catppuccin/groups/integrations/snacks.lua
@@ -157,10 +157,6 @@ function M.get()
 		hlgroups["SnacksPicker"] = { link = "NormalFloat" }
 		hlgroups["SnacksPickerBorder"] = { link = "FloatBorder" }
 		hlgroups["SnacksPickerInputBorder"] = { link = "SnacksPickerBorder" }
-		hlgroups["SnacksPickerInput"] = {
-			fg = C.text,
-			bg = C.none,
-		}
 		hlgroups["SnacksPickerPrompt"] = {
 			fg = C.flamingo,
 			bg = C.none,


### PR DESCRIPTION
<img width="769" height="81" alt="Screenshot 2025-07-31 111017" src="https://github.com/user-attachments/assets/46121870-f46b-497c-b221-a93b07b3f043" />

fixed snacks picker input field bg color, now it has the same color as rest of the window.