### PR TITLE
feat(editor): align pmenu styling with vscode

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -50,14 +50,14 @@ function M.get()
 		} or { fg = C.subtext0, bg = (O.float.transparent and vim.o.winblend == 0) and C.none or C.mantle }, -- Title of floating windows
 		FloatShadow = { fg = (O.float.transparent and vim.o.winblend == 0) and C.none or C.overlay0 },
 		Pmenu = {
-			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or U.darken(C.surface0, 0.8, C.crust),
+			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or C.mantle,
 			fg = C.overlay2,
 		}, -- Popup menu: normal item.
-		PmenuSel = { bg = C.surface1, style = { "bold" } }, -- Popup menu: selected item.
-		PmenuSbar = { bg = C.surface1 }, -- Popup menu: scrollbar.
+		PmenuSel = { bg = C.surface0, style = { "bold" } }, -- Popup menu: selected item.
+		PmenuSbar = { bg = C.surface0 }, -- Popup menu: scrollbar.
 		PmenuThumb = { bg = C.overlay0 }, -- Popup menu: Thumb of the scrollbar.
 		PmenuExtra = { fg = C.overlay0 }, -- Popup menu: normal item extra text.
-		PmenuExtraSel = { fg = C.overlay0 }, -- Popup menu: selected item extra text.
+		PmenuExtraSel = { fg = C.overlay0, style = { "bold" } }, -- Popup menu: selected item extra text.
 		Question = { fg = C.blue }, -- |hit-enter| prompt and yes/no questions
 		QuickFixLine = { bg = C.surface1, style = { "bold" } }, -- Current |quickfix| item in the quickfix window. Combined with |hl-CursorLine| when the cursor is there.
 		Search = { bg = U.darken(C.sky, 0.30, C.base), fg = C.text }, -- Last search pattern highlighting (see 'hlsearch').  Also used for similar items that need to stand out.

--- a/lua/catppuccin/groups/integrations/blink_cmp.lua
+++ b/lua/catppuccin/groups/integrations/blink_cmp.lua
@@ -48,7 +48,7 @@ function M.get()
 		-- uses FloatBorder.fg and Pmenu.bg
 		highlights["BlinkCmpMenuBorder"] = {
 			fg = O.float.solid and ((O.float.transparent and vim.o.winblend == 0) and C.surface2 or C.mantle) or C.blue,
-			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or U.darken(C.surface0, 0.8, C.crust),
+			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or C.mantle,
 		}
 		highlights["BlinkCmpDocBorder"] = { link = "FloatBorder" }
 	end


### PR DESCRIPTION
bring the current pmenu styling to be more in line with the current vscode style

this change is based on the personal preferences of the maintainers of this project. it has nothing to do with the popularity of vscode :)