### PR TITLE
feat(blink): link signature help window border to `FloatBorder`

### DIFF
--- a/lua/catppuccin/groups/integrations/blink_cmp.lua
+++ b/lua/catppuccin/groups/integrations/blink_cmp.lua
@@ -15,6 +15,7 @@ function M.get()
 		BlinkCmpScrollBarThumb = { bg = C.overlay0 },
 		BlinkCmpLabelDescription = { fg = C.overlay0 },
 		BlinkCmpLabelDetail = { fg = C.overlay0 },
+		BlinkCmpSignatureHelpBorder = { link = "FloatBorder" },
 
 		BlinkCmpKindText = { fg = C.green },
 		BlinkCmpKindMethod = { fg = C.blue },


### PR DESCRIPTION
If you set a border for signature help windows of blink.cmp, they are always white because they are linked to `NormalFloat` by default.

Before:

<img width="1153" height="135" alt="image" src="https://github.com/user-attachments/assets/158d8e4c-b144-4f1f-bccd-9432ad45701b" />

After (follows the `float` option, in this case `solid = true`): 

<img width="1140" height="149" alt="image" src="https://github.com/user-attachments/assets/9ad0cf5d-97be-44b6-a355-1c072d0769b8" />
