### PR TITLE
fix(integrations/colorful_winsep): update hl name

### DIFF
--- a/lua/catppuccin/groups/integrations/colorful_winsep.lua
+++ b/lua/catppuccin/groups/integrations/colorful_winsep.lua
@@ -2,7 +2,7 @@ local M = {}
 
 function M.get()
 	return {
-		NvimSeparator = {
+		ColorfulWinSep = {
 			fg = C[O.integrations.colorful_winsep.color],
 			bg = O.transparent_background and C.none or C.base,
 		},


### PR DESCRIPTION

fixes #912

<https://github.com/nvim-zh/colorful-winsep.nvim/commit/642afcd59d900b2ab2493fa7f03e64a1f7eeb8b5>
