### PR TITLE
fix: lazy plugins are in a dictionary rather than a list

### DIFF
--- a/lua/catppuccin/lib/detect_integrations.lua
+++ b/lua/catppuccin/lib/detect_integrations.lua
@@ -18,9 +18,7 @@ function M.detect_plugins()
 	if pcall(require, "pckr") then vim.list_extend(installed_plugins, require("pckr.plugin").plugins_by_name) end
 
 	if pcall(require, "lazy") then
-		for plugin, _ in pairs(require("lazy.core.config").plugins) do
-			table.insert(installed_plugins, plugin)
-		end
+		vim.list_extend(installed_plugins, vim.tbl_keys(require("lazy.core.config").plugins))
 	end
 
 	local seen = {}


### PR DESCRIPTION
Fixes bug introduced in #909 where plugins from lazy.nvim are in a dictionary format rather than a list. This resolves the issue by properly populating the installed plugins list