### PR TITLE
fix(integrations)!: rename `get()` to `get_*()` on abnormal integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ local ctp_feline = require('catppuccin.groups.integrations.feline')
 ctp_feline.setup()
 
 require("feline").setup({
-    components = ctp_feline.get(),
+    components = ctp_feline.get_statusline(),
 })
 ```
 
@@ -668,7 +668,7 @@ vim.api.nvim_create_autocmd("ColorScheme", {
         package.loaded["feline"] = nil
         package.loaded["catppuccin.groups.integrations.feline"] = nil
         require("feline").setup {
-            components = require("catppuccin.groups.integrations.feline").get(),
+            components = require("catppuccin.groups.integrations.feline").get_statusline(),
         }
     end,
 })

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ use "akinsho/bufferline.nvim" {
   after = "catppuccin",
   config = function()
     require("bufferline").setup {
-      highlights = require("catppuccin.groups.integrations.bufferline").get()
+      highlights = require("catppuccin.groups.integrations.bufferline").get_theme()
     }
   end
 }
@@ -411,7 +411,7 @@ Configurations are self-explanatory, see `:h bufferline-highlights` for detailed
 ```lua
 local mocha = require("catppuccin.palettes").get_palette "mocha"
 bufferline.setup {
-    highlights = require("catppuccin.groups.integrations.bufferline").get {
+    highlights = require("catppuccin.groups.integrations.bufferline").get_theme {
         styles = { "italic", "bold" },
         custom = {
             all = {

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -324,7 +324,7 @@ Update your bufferline config to use the Catppuccin components:
       after = "catppuccin",
       config = function()
         require("bufferline").setup {
-          highlights = require("catppuccin.groups.integrations.bufferline").get()
+          highlights = require("catppuccin.groups.integrations.bufferline").get_theme()
         }
       end
     }
@@ -336,7 +336,7 @@ explanations:
 >lua
     local mocha = require("catppuccin.palettes").get_palette "mocha"
     bufferline.setup {
-        highlights = require("catppuccin.groups.integrations.bufferline").get {
+        highlights = require("catppuccin.groups.integrations.bufferline").get_theme {
             styles = { "italic", "bold" },
             custom = {
                 all = {
@@ -431,7 +431,7 @@ Update your Feline config to use the Catppuccin components:
     ctp_feline.setup()
     
     require("feline").setup({
-        components = ctp_feline.get(),
+        components = ctp_feline.get_statusline(),
     })
 <
 
@@ -523,7 +523,7 @@ Here are the defaults:
             package.loaded["feline"] = nil
             package.loaded["catppuccin.groups.integrations.feline"] = nil
             require("feline").setup {
-                components = require("catppuccin.groups.integrations.feline").get(),
+                components = require("catppuccin.groups.integrations.feline").get_statusline(),
             }
         end,
     })

--- a/lua/catppuccin/groups/integrations/bufferline.lua
+++ b/lua/catppuccin/groups/integrations/bufferline.lua
@@ -5,7 +5,7 @@ M.url = "https://github.com/akinsho/bufferline.nvim"
 local ctp = require "catppuccin"
 local O = ctp.options
 
-function M.get(user_config)
+function M.get_theme(user_config)
 	user_config = user_config or {}
 	-- Backward compatibility
 	if O.integrations.bufferline then return {} end

--- a/lua/catppuccin/groups/integrations/feline.lua
+++ b/lua/catppuccin/groups/integrations/feline.lua
@@ -106,7 +106,7 @@ if ok then
 		view = vim.tbl_deep_extend("force", view, opts.view)
 	end
 
-	function M.get()
+	function M.get_statusline()
 		local shortline = false
 
 		local components = {

--- a/lua/catppuccin/lib/mapper.lua
+++ b/lua/catppuccin/lib/mapper.lua
@@ -45,12 +45,9 @@ function M.apply(flavour)
 			end
 		end
 
-		if cot then
-			final_integrations = vim.tbl_deep_extend(
-				"force",
-				final_integrations,
-				require("catppuccin.groups.integrations." .. integration).get()
-			)
+		local ok, result = pcall(require, "catppuccin.groups.integrations." .. integration)
+		if ok and result.get and cot then
+			final_integrations = vim.tbl_deep_extend("force", final_integrations, result.get())
 		end
 	end
 


### PR DESCRIPTION
- **fix(lib/mapper): allow for integrations without `get()` field**
  

- **fix(integrations/feline): rename `get()` to `get_statusline()`**
  

- **fix(integrations/bufferline): rename `get()` to `get_theme()`**

theres an issue where some integrations should never be able to get enabled through the config options: if they do it will error because the returned value will be assumed to be a highlights table. this will obviously cause issues when the returned value is not meant to be passed to `vim.api.nvim_set_hl()`, like with feline and bufferline.

this issue is occuring because the `auto_integrations` enables these special integrations if the plugin is detected.