### PR TITLE
:zap: Make neotree transparency seperated from global configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1013,7 +1013,10 @@ mini = {
 <td>
 
 ```lua
-neotree = true
+neotree = {
+    enabled = true,
+    transparent = false,
+}
 ```
 
 </td>

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -677,7 +677,10 @@ mini.nvim>lua
 <
 
 neo-tree.nvim>lua
-    neotree = true
+    neotree = {
+        enabled = true,
+        transparent = false,
+    }
 <
 
 neogit>lua

--- a/lua/catppuccin/groups/integrations/neotree.lua
+++ b/lua/catppuccin/groups/integrations/neotree.lua
@@ -3,8 +3,8 @@ local M = {}
 M.url = "https://github.com/nvim-neo-tree/neo-tree.nvim"
 
 function M.get()
-	local active_bg = O.transparent_background and C.none or C.mantle
-	local inactive_bg = O.transparent_background and C.none or C.base
+	local active_bg = O.neotree.transparent or and C.none or C.mantle
+	local inactive_bg = O.neotree.transparent or and C.none or C.base
 	return {
 		NeoTreeDirectoryName = { fg = C.blue },
 		NeoTreeDirectoryIcon = { fg = C.blue },
@@ -38,8 +38,8 @@ function M.get()
 		NeoTreeTabSeparatorInactive = { fg = inactive_bg, bg = inactive_bg },
 		NeoTreeVertSplit = { fg = C.base, bg = inactive_bg },
 		NeoTreeWinSeparator = {
-			fg = O.transparent_background and C.surface1 or C.base,
-			bg = O.transparent_background and C.none or C.base,
+			fg = O.neotree.transparent or and C.surface1 or C.base,
+			bg = O.neotree.transparent or and C.none or C.base,
 		},
 		NeoTreeStatusLineNC = { fg = C.mantle, bg = C.mantle },
 	}

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -56,7 +56,7 @@ local M = {
 			markdown = true,
 			neogit = true,
 			neotree = {
-				enable = true,
+				enabled = true,
 				transparent = false,
 			},
 			nvimtree = true,

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -55,7 +55,10 @@ local M = {
 			gitsigns = true,
 			markdown = true,
 			neogit = true,
-			neotree = true,
+			neotree = {
+				enable = true,
+				transparent = false,
+			},
 			nvimtree = true,
 			ufo = true,
 			rainbow_delimiters = true,

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -109,6 +109,10 @@
 -- Toggle the background of inlay hints.
 ---@field background boolean?
 
+---@class CtpNeoTreeIntegrations
+---@field enable boolean?
+---@field transparent boolean?
+
 ---@class CtpIntegrations
 ---@field aerial boolean?
 ---@field alpha boolean?
@@ -199,7 +203,7 @@
 ---@field navic CtpIntegrationNavic | boolean?
 ---@field neogit boolean?
 ---@field neotest boolean?
----@field neotree boolean?
+---@field neotree CtpNeoTreeIntegrations?
 ---@field noice boolean?
 ---@field notify boolean?
 ---@field nvim_surround boolean?

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -110,7 +110,7 @@
 ---@field background boolean?
 
 ---@class CtpNeoTreeIntegrations
----@field enable boolean?
+---@field enabled boolean?
 ---@field transparent boolean?
 
 ---@class CtpIntegrations


### PR DESCRIPTION
🎉 First off, thanks for taking the time to contribute! 🎉

Here are some guidelines:
- Format code using [stylua](https://github.com/johnnymorganz/stylua).
- New plugin integration should be added in alphabetical order:
  - to the [README](https://github.com/catppuccin/nvim#integrations) (vimdoc is auto-generated).
  - to [types.lua](https://github.com/catppuccin/nvim/blob/main/lua/catppuccin/types.lua)
- Create a topic branch on your fork for your specific PR.
- Use [conventionalcommits.org's](https://www.conventionalcommits.org/en/v1.0.0/)
  rules for explicit and meaningful commit messages.
- If it's your first time contributing to a project, then read
  [About pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
  on Github's docs.

Here are some tips:
- Use `vim.g.catppuccin_debug = true` to get live config re-loading
