### PR TITLE
docs(README): Replace deprecated packer.nvim with built-in package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ This port of <a href="https://github.com/catppuccin/">Catppuccin</a> is special 
 
 ## Installation
 
+[Neovim built-in plugin manager](https://neovim.io/doc/user/pack.html)
+```lua
+vim.pack.add { "https://github.com/catppuccin/nvim" }
+```
+
 [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
 { "catppuccin/nvim", name = "catppuccin", priority = 1000 }
@@ -60,11 +65,6 @@ This port of <a href="https://github.com/catppuccin/">Catppuccin</a> is special 
 [mini.deps](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-deps.md)
 ```lua
 add({ source = "catppuccin/nvim", name = "catppuccin" })
-```
-
-[packer.nvim](https://github.com/wbthomason/packer.nvim)
-```lua
-use { "catppuccin/nvim", as = "catppuccin" }
 ```
 
 [vim-plug](https://github.com/junegunn/vim-plug)


### PR DESCRIPTION
Motivation behind that is simple: I am migrating from lazy to built-in plugin manager. /jk

Basically packer.nvim is deprecated where the message in readme states: "NOTICE:

This repository is currently unmaintained. For the time being (as of August, 2023), it is recommended to use one of the following plugin managers instead: ...".

It's already deprecated for 2 years. That's why I thought it would be a good idea to replace packer.nvim with a new built-in plugin manager. One removed, one added.