### PR TITLE
fix: config `float` is optional in setup

### DIFF
--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -15,7 +15,7 @@
 ---@field compile_path string?
 -- Whether to enable transparency.
 ---@field transparent_background boolean?
----@field float CtpFloatOpts
+---@field float CtpFloatOpts?
 -- Toggle the `~` characters after the end of buffers.
 ---@field show_end_of_buffer boolean?
 -- If true, sets terminal colors (e.g. `g:terminal_color_0`).


### PR DESCRIPTION
All other config fields are optional (or explicitly nil). This field technically is also optional. The PR matches code and types.

The other fields that are not optional are sub-fields found in classes (of optional fields)

<details><summary>Why I made this PR</summary>
<p>

In my personal config, I keep getting the following warning:

```
1. Missing required fields in type `CatppuccinOptions`: `float` [missing-fields]
```

Config for context:

```lua
{
    -- Theme
    "catppuccin/nvim",
    name = "catppuccin",
    priority = 1000,
    config = function()
      require("catppuccin").setup({
        auto_integrations = true,
        flavour = "mocha"
      })
      vim.cmd.colorscheme "catppuccin"
    end,
  }
```

Simple enough fix for a simple enough annoyance.

</p>
</details> 