### PR TITLE
fix(treesitter): set `@type.builtin` as italic

### DIFF
--- a/lua/catppuccin/groups/treesitter.lua
+++ b/lua/catppuccin/groups/treesitter.lua
@@ -46,7 +46,7 @@ If you want to stay on nvim 0.7, pin catppuccin tag to v0.2.4 and nvim-treesitte
 
 		-- Types
 		["@type"] = { link = "Type" }, -- For types.
-		["@type.builtin"] = { fg = C.mauve, style = O.styles.properties or { "italic" } }, -- For builtin types.
+		["@type.builtin"] = { fg = C.mauve, style = O.styles.types or {} }, -- For builtin types.
 		["@type.definition"] = { link = "Type" }, -- type definitions (e.g. `typedef` in C)
 
 		["@attribute"] = { link = "Constant" }, -- attribute annotations (e.g. Python decorators)


### PR DESCRIPTION
Hello,

`styles.properties` is set as `{}` in the default config, which is truthy in Lua. Therefore, to actually fall back to italic, users would have to set `styles.properties` to `nil` (which I'm assuming is unintended behavior).

Alternatively, `@type.builtin` could be italic by default.