### PR TITLE
feat(editor): link MsgSeparator

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -25,7 +25,7 @@ function M.get()
 		MatchParen = { fg = C.peach, bg = C.surface1, style = { "bold" } }, -- The character under the cursor or just before it, if it is a paired bracket, and its match. |pi_paren.txt|
 		ModeMsg = { fg = C.text, style = { "bold" } }, -- 'showmode' message (e.g., "-- INSERT -- ")
 		-- MsgArea = { fg = C.text }, -- Area for messages and cmdline, don't set this highlight because of https://github.com/neovim/neovim/issues/17832
-		MsgSeparator = {}, -- Separator for scrolled messages, `msgsep` flag of 'display'
+		MsgSeparator = { link = "WinSeparator" }, -- Separator for scrolled messages, `msgsep` flag of 'display'
 		MoreMsg = { fg = C.blue }, -- |more-prompt|
 		NonText = { fg = C.overlay0 }, -- '@' at the end of the window, characters from 'showbreak' and other characters that do not really exist in the text (e.g., ">" displayed when a double-wide character doesn't fit at the end of the line). See also |hl-EndOfBuffer|.
 		Normal = { fg = C.text, bg = O.transparent_background and C.none or C.base }, -- normal text


### PR DESCRIPTION
Hello,

The docs mention that `MsgSeparator` is used for an obsolete flag for a specific option. But with nvim 0.12 (nightly), it got a new usage: with the new UI, it's actually used as a separator when viewing the last message (via `g<`).

Before:

<img width="1921" height="472" alt="image" src="https://github.com/user-attachments/assets/e1a56d76-37eb-4554-8ba3-014a4eb31a80" />

After:

<img width="1921" height="264" alt="image" src="https://github.com/user-attachments/assets/6965d599-e50a-4930-9149-e046616d2728" />
 