### PR TITLE
Fix: string index error causes failed load in kitty

### DIFF
--- a/lua/catppuccin/palettes/init.lua
+++ b/lua/catppuccin/palettes/init.lua
@@ -18,8 +18,8 @@ function M.get_palette(flavour)
 	--]]
 	if O.kitty then
 		for accent, hex in pairs(ans) do
-			local red_green_string = hex:sub(1, 5)
-			local blue_value = tonumber(hex:sub(6, 7), 16)
+			local red_green_string = hex:sub(1, 4)
+			local blue_value = tonumber(hex:sub(5, 6), 16)
 
 			-- Slightly increase or decrease brightness of the blue channel
 			blue_value = blue_value == 255 and blue_value - 1 or blue_value + 1


### PR DESCRIPTION
```lua
local red_green_string = hex:sub(1, 5)
local blue_value = tonumber(hex:sub(6, 7), 16)
```

would read the first 5 digits as red-green and the last digit as blue

then
```lua 
ans[accent] = string.format("%s%.2x", red_green_string, blue_value)
```
would format the 6th digit to be 2 characters wide.

So the hex_to_rgb would parse a 7-digit hex code and crash
