### PR TITLE
fix(trouble): fix inconsistent highlight for unfocused trouble.nvim w…

### DIFF
--- a/lua/catppuccin/groups/integrations/lsp_trouble.lua
+++ b/lua/catppuccin/groups/integrations/lsp_trouble.lua
@@ -7,7 +7,7 @@ function M.get()
 		TroubleText = { fg = C.green },
 		TroubleCount = { fg = C.pink, bg = O.transparent_background and C.none or C.surface1 },
 		TroubleNormal = { fg = C.text, bg = O.transparent_background and C.none or C.crust },
-		TroubleNormalNC = { fg = C.text, bg = O.transparent_background and C.none or C.crust },
+		TroubleNormalNC = { link = "TroubleNormal" },
 	}
 end
 


### PR DESCRIPTION
Fix inconsistent highlight for unfocused `trouble.nvim` window.

Before:
<img width="935" height="324" alt="catppuccin-trouble-before" src="https://github.com/user-attachments/assets/cc7f8764-1e54-4c6e-9c82-5f352e84cb70" />

After:
<img width="935" height="324" alt="catppuccin-trouble-after" src="https://github.com/user-attachments/assets/a34bf5c2-8b09-48ab-9a87-aeab5236661c" />
