### PR TITLE
feat: Add link for readonly variables in semantic tokens

### DIFF
--- a/lua/catppuccin/groups/semantic_tokens.lua
+++ b/lua/catppuccin/groups/semantic_tokens.lua
@@ -27,6 +27,7 @@ If you want to stay on nvim 0.7, pin catppuccin tag to v0.2.4 and nvim-treesitte
 		-- allow lsp to override treesitter
 		["@lsp.typemod.function.defaultLibrary"] = { link = "@function.builtin" },
 		["@lsp.typemod.function.builtin"] = { link = "@function.builtin" },
+		["@lsp.typemod.variable.readonly"] = { link = "@constant" },
 	}
 end
 


### PR DESCRIPTION
Catppuccin is wonderful and I use it everyday in neovim. But I've found that this colorscheme can't deal with constants well because it doesn't use lsp semantic hl capability. Constants/Readonly vars are always way better using lsp semantic hl than treesitter hl, so I make this pr. Feel free to make some tweeks and give me some feedbacks to improve this pr.