### PR TITLE
fix: Change FloatShadow from fg to bg color

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -49,6 +49,7 @@ function M.get()
 			bg = C.lavender,
 		} or { fg = C.subtext0, bg = (O.float.transparent and vim.o.winblend == 0) and C.none or C.mantle }, -- Title of floating windows
 		FloatShadow = { bg = (O.float.transparent and vim.o.winblend == 0) and C.none or C.overlay0, blend = 80 },
+		FloatShadowThrough = { bg = (O.float.transparent and vim.o.winblend == 0) and C.none or C.overlay0, blend = 100 },
 		Pmenu = {
 			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or C.mantle,
 			fg = C.overlay2,


### PR DESCRIPTION
Hello catppuccin/nvim maintainers. I have found a bug that `set winborder=shadow` doesn't work in this colorscheme and I make a fix by changing the FloatShadow hl group.
