### PR TITLE
fix: use link.label for html

### DIFF
--- a/lua/catppuccin/groups/treesitter.lua
+++ b/lua/catppuccin/groups/treesitter.lua
@@ -178,7 +178,6 @@ If you want to stay on nvim 0.7, pin catppuccin tag to v0.2.4 and nvim-treesitte
 
 		-- HTML
 		["@string.special.url.html"] = { fg = C.green }, -- Links in href, src attributes.
-		["@markup.link.label.html"] = { fg = C.text }, -- Text between <a></a> tags.
 		["@character.special.html"] = { fg = C.red }, -- Symbols such as &nbsp;.
 
 		-- Lua


### PR DESCRIPTION
Hello,

Currently, HTML has a special treatment regarding `link.label`: it links to `text`. However, I think that's an oversight, since it doesn't affect other HTML-like languages. For instance, here, the top file is Svelte and the bottom one is raw HTML:

<img width="565" height="389" alt="image" src="https://github.com/user-attachments/assets/d5b94d27-c590-4d26-896c-a949401af241" />

Well, I guess this could also be fixed by going the other way. Let me know if that's preferred.