### PR TITLE
feat(snacks): use overlay2 as default indent_scope_color

### DIFF
--- a/README.md
+++ b/README.md
@@ -1501,7 +1501,7 @@ render_markdown = true
 ```lua
 snacks = {
     enabled = false,
-    indent_scope_color = "", -- catppuccin color (eg. `lavender`) Default: text
+    indent_scope_color = "", -- catppuccin color (eg. `lavender`) Default: overlay2
 }
 ```
 

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -912,7 +912,7 @@ render-markdown.nvim>lua
 snacks.nvim>lua
     snacks = {
         enabled = false,
-        indent_scope_color = "", -- catppuccin color (eg. `lavender`) Default: text
+        indent_scope_color = "", -- catppuccin color (eg. `lavender`) Default: overlay2
     }
 <
 

--- a/lua/catppuccin/groups/integrations/snacks.lua
+++ b/lua/catppuccin/groups/integrations/snacks.lua
@@ -51,7 +51,7 @@ function M.get()
 		SnacksDashboardTitle = { link = "Title" },
 
 		SnacksIndent = { fg = C.surface0 },
-		SnacksIndentScope = { fg = C[indent_scope_color] or C.text },
+		SnacksIndentScope = { fg = C[indent_scope_color] or C.overlay2 },
 
 		SnacksPickerSelected = {
 			fg = O.float.transparent and C.flamingo or C.text,


### PR DESCRIPTION
This PR updates the `snacks.indent` integration to use `overlay2` as the color for indent scopes. This is in line with the integration for similar plugins ([`blink.indent`](https://github.com/catppuccin/nvim/blob/c4d475e4b5684747cde9b3f849186af7837d4397/lua/catppuccin/groups/integrations/blink_indent.lua#L8), [`mini.indentscope`](https://github.com/catppuccin/nvim/blob/c4d475e4b5684747cde9b3f849186af7837d4397/lua/catppuccin/groups/integrations/mini.lua#L79)) which also use `overlay2`. The current default is `text` which looks too bright.

## Screenshots

Using `flavour = "macchiato"`

### After

<img width="784" height="824" alt="image" src="https://github.com/user-attachments/assets/fdf5bc10-364a-41cd-ae9e-17d694fedf59" />

### Before

<img width="784" height="824" alt="image" src="https://github.com/user-attachments/assets/21d82e77-dbc4-498a-ba50-ff00bb070245" />