### PR TITLE
chore: update `catppuccin` colorscheme name

### DIFF
--- a/tests/setup_spec.lua
+++ b/tests/setup_spec.lua
@@ -1615,7 +1615,7 @@ describe("user", function()
 			assert.equals(
 				pcall(function()
 					require("catppuccin").compile()
-					vim.cmd.colorscheme("catppuccin")
+					vim.cmd.colorscheme("catppuccin-nvim")
 				end),
 				true
 			)


### PR DESCRIPTION
fixup 6d4e80f8bde41b893c9bc7b07460af3155a3adfa
