### PR TITLE
fix!: remove `O.show_end_of_buffer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ require("catppuccin").setup({
         transparent = false, -- enable transparent floating windows
         solid = false, -- use solid styling for floating windows, see |winborder|
     },
-    show_end_of_buffer = false, -- shows the '~' characters after the end of buffers
     term_colors = false, -- sets terminal colors (e.g. `g:terminal_color_0`)
     dim_inactive = {
         enabled = false, -- dims the background color of inactive window

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -92,7 +92,6 @@ options and settings.
             transparent = false, -- enable transparent floating windows
             solid = false, -- use solid styling for floating windows, see |winborder|
         },
-        show_end_of_buffer = false, -- shows the '~' characters after the end of buffers
         term_colors = false, -- sets terminal colors (e.g. `g:terminal_color_0`)
         dim_inactive = {
             enabled = false, -- dims the background color of inactive window

--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -12,7 +12,7 @@ function M.get()
 			bg = U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),
 		}, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if forecrust (ctermfg OR guifg) is not set.
 		Directory = { fg = C.blue }, -- directory names (and other special names in listings)
-		EndOfBuffer = { fg = O.show_end_of_buffer and C.surface1 or C.base }, -- filler lines (~) after the end of the buffer.  By default, this is highlighted like |hl-NonText|.
+		EndOfBuffer = { fg = C.surface1 }, -- filler lines (~) after the end of the buffer. By default, this is highlighted like |hl-NonText|.
 		ErrorMsg = { fg = C.red, style = { "bold", "italic" } }, -- error messages on the command line
 		VertSplit = { fg = O.transparent_background and C.surface1 or C.crust }, -- the column separating vertically split windows
 		Folded = { fg = C.blue, bg = O.transparent_background and C.none or C.surface1 }, -- line used for closed folds

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -12,7 +12,6 @@ local M = {
 			transparent = false,
 			solid = false,
 		},
-		show_end_of_buffer = false,
 		term_colors = false,
 		kitty = vim.env.KITTY_WINDOW_ID and true or false,
 		dim_inactive = {

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -16,8 +16,6 @@
 -- Whether to enable transparency.
 ---@field transparent_background boolean?
 ---@field float CtpFloatOpts?
--- Toggle the `~` characters after the end of buffers.
----@field show_end_of_buffer boolean?
 -- If true, sets terminal colors (e.g. `g:terminal_color_0`).
 ---@field term_colors boolean?
 -- Workaround for kitty transparency issue: https://github.com/kovidgoyal/kitty/issues/2917


### PR DESCRIPTION
removing this option since its behavior is dependent on a non-transparent background.

if users want to keep this, they should use:
```lua
vim.opt.fillchars:append({ eob = " " })
```

fix https://github.com/catppuccin/nvim/issues/980