### PR TITLE
feat(neogit): support inline highlights

### DIFF
--- a/lua/catppuccin/groups/integrations/neogit.lua
+++ b/lua/catppuccin/groups/integrations/neogit.lua
@@ -50,9 +50,17 @@ function M.get()
 			bg = U.darken(C.red, 0.095, C.base),
 			fg = U.darken(C.red, 0.800, C.base),
 		},
+		NeogitDiffDeleteInline = {
+			bg = U.darken(C.red, 0.500, C.base),
+			style = { "bold" },
+		},
 		NeogitDiffAdd = {
 			bg = U.darken(C.green, 0.095, C.base),
 			fg = U.darken(C.green, 0.800, C.base),
+		},
+		NeogitDiffAddInline = {
+			bg = U.darken(C.green, 0.500, C.base),
+			style = { "bold" },
 		},
 		NeogitCommitViewHeader = {
 			bg = U.darken(C.blue, 0.300, C.base),


### PR DESCRIPTION
Hello,

Recently, neogit added [inline](https://github.com/NeogitOrg/neogit/pull/1928) highlights.

## Before:
<img width="950" height="193" alt="image" src="https://github.com/user-attachments/assets/a299ea52-eb02-4d4d-91ad-588b9812967b" />

### Hunk selected

<img width="987" height="201" alt="image" src="https://github.com/user-attachments/assets/5e5d03e0-5ced-4c10-a25a-a968601ab2c8" />

## After

<img width="975" height="191" alt="image" src="https://github.com/user-attachments/assets/34ae8249-2806-4448-8b6c-ec0b2c26aac5" />

### Hunk selected

<img width="976" height="196" alt="image" src="https://github.com/user-attachments/assets/571568a5-2d1d-45d5-978a-b887e65ebb10" />

---

Tried going with a background that would look nice on both scenarios (contrast isn't easy). Also didn't want to introduce a foreground color (like the original), to preserve treesitter highlighting.
