### PR TITLE
fix(terminal): prevent tmate crash when entering terminal insert mode

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -87,8 +87,8 @@ function M.get()
 		TabLine = { bg = C.crust, fg = C.overlay0 }, -- tab pages line, not active tab page label
 		TabLineFill = { bg = O.transparent_background and C.none or C.mantle }, -- tab pages line, where there are no labels
 		TabLineSel = { link = "Normal" }, -- tab pages line, active tab page label
-		TermCursor = { fg = C.base, bg = C.rosewater }, -- cursor in a focused terminal
-		TermCursorNC = { fg = C.base, bg = C.overlay2 }, -- cursor in unfocused terminals
+		TermCursor = { fg = C.none, bg = C.none }, -- cursor in a focused terminal
+		TermCursorNC = { fg = C.none, bg = C.none }, -- cursor in unfocused terminals
 		Title = { fg = C.blue, style = { "bold" } }, -- titles for output from ":set all", ":autocmd" etc.
 		Visual = { bg = C.surface1, style = { "bold" } }, -- Visual mode selection
 		VisualNOS = { bg = C.surface1, style = { "bold" } }, -- Visual mode selection when vim is "Not Owning the Selection".


### PR DESCRIPTION
# fix(terminal): prevent tmate crash when entering terminal insert mode

Closes #924

---

## What was happening

If you were using **tmate** (not tmux, tmate specifically), opening a `:terminal` buffer in Neovim and pressing `i` to type something would kill the tmate session. Not just the Neovim instance, the whole tmate session would crash and the terminal behave in a strange way.

The root of the problem is directly in the values assigned to `TermCursor` and `TermCursorNC`. Those two highlight groups were set to explicit fg/bg colors, which is what triggers the crash.

The reporter found a temporary fix on their own by overriding those highlights and just remove them in their personal config:

```lua
highlight_overrides = {
  all = function()
    return {
      TermCursor   = { fg = "NONE", bg = "NONE" },
      TermCursorNC = { fg = "NONE", bg = "NONE" },
    }
  end,
}
```

That workaround is correct, and I thought about persisting in the editor's configs directly and this is what the PR does.

---

## Why it was crashing

The two highlight groups responsible are:

```lua
TermCursor   = { fg = C.base, bg = C.rosewater }
TermCursorNC = { fg = C.base, bg = C.overlay2  }
```

When Neovim enters terminal insert mode, it emits escape sequences to apply those specific colors to the cursor. tmux handles those sequences fine. tmate does not — it crashes hard, taking the whole session with it.

Setting them to `NONE` stops Neovim from emitting those sequences entirely. The terminal emulator then renders the cursor its own way, which is safe and works everywhere.

---

## The change

I have overrided the editor script two lines directly — `lua/catppuccin/groups/editor.lua`:

---

## How I tested it

Open a tmate session and exec these commands:

**Confirming the fix is applied (headless, no tmate needed):**

```bash
nvim --headless --clean -u NONE \
  --cmd "set rtp+=/...pathToThisRepo" \
  -c "lua require('catppuccin').setup(); vim.cmd.colorscheme('catppuccin-nvim')" \
  -c "lua io.write('TermCursor: ' .. vim.inspect(vim.api.nvim_get_hl(0, {name='TermCursor'})) .. '\n')" \
  -c "lua io.write('TermCursorNC: ' .. vim.inspect(vim.api.nvim_get_hl(0, {name='TermCursorNC'})) .. '\n')" \
  -c "q"
```

Expected output — both groups empty (no colors forced):
```
TermCursor: vim.empty_dict()
TermCursorNC: vim.empty_dict()
```

**Confirming the crash is gone (inside tmate):**

```bash
# patched version — survives :terminal → i
nvim --cmd "set rtp+=/...pathToThisRepo" \
  -c "lua require('catppuccin').setup(); vim.cmd.colorscheme('catppuccin-nvim')"

# upstream version — crashes on :terminal → i (confirms the bug was real)
git clone --depth 1 https://github.com/catppuccin/nvim.git /tmp/catppuccin-upstream
nvim --cmd "set rtp+=/tmp/catppuccin-upstream" \
  -c "lua require('catppuccin').setup(); vim.cmd.colorscheme('catppuccin')"
```
