### PR TITLE
feat(octo): support inline highlights

### DIFF
--- a/lua/catppuccin/groups/integrations/octo.lua
+++ b/lua/catppuccin/groups/integrations/octo.lua
@@ -75,6 +75,8 @@ function M.get()
 		OctoGreenFloat = { fg = C.green, bg = C.base },
 		OctoGreyFloat = { fg = C.text, bg = C.base },
 		OctoBlueFloat = { fg = C.blue, bg = C.base },
+		OctoReviewDiffAddText = { bg = U.darken(C.green, 0.30, C.base) },
+		OctoReviewDiffDeleteText = { bg = U.darken(C.red, 0.30, C.base) },
 	}
 end
 


### PR DESCRIPTION
Similarly to #986, octo had some recent [changes](https://github.com/pwntester/octo.nvim/commit/bbd903ce905c301ac516d64c33b2511a05f6b59b) regarding inline hl groups.

### Before

(atrocious alert)

<img width="1515" height="547" alt="image" src="https://github.com/user-attachments/assets/bd4a7cb0-f6ad-4da7-b79d-101a70f1a42d" />


### After

<img width="1551" height="495" alt="image" src="https://github.com/user-attachments/assets/97e39c14-83e5-4d4b-ad46-53760dde5a71" />
