### PR TITLE
feat(hl/editor): add Dimmed hl

### DIFF
--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -1,4 +1,5 @@
 *catppuccin.txt*                              Soothing pastel theme for NeoVim
+                                 For nvim >= 0.8.0    Last change: 2026 May 20
 
 ==============================================================================
 Table of Contents                               *catppuccin-table-of-contents*
@@ -460,7 +461,7 @@ Setting `enabled` to `true` enables this integration.
   options will also apply to coc
 In the nested tables you can set the style for the diagnostics, both
 `virtual_text` (what you see on the side) and `underlines` (what points
-directly at the thing (e.g. an error)).
+directly at the thing (e.g. an error)).
 
 >lua
     lsp_styles = {

--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -11,6 +11,7 @@ function M.get()
 		CursorLine = {
 			bg = U.vary_color({ latte = U.lighten(C.mantle, 0.70, C.base) }, U.darken(C.surface0, 0.64, C.base)),
 		}, -- Screen-line at the cursor, when 'cursorline' is set.  Low-priority if forecrust (ctermfg OR guifg) is not set.
+		Dimmed = { fg = C.overlay1 },
 		Directory = { fg = C.blue }, -- directory names (and other special names in listings)
 		EndOfBuffer = { fg = C.surface1 }, -- filler lines (~) after the end of the buffer. By default, this is highlighted like |hl-NonText|.
 		ErrorMsg = { fg = C.red, style = { "bold", "italic" } }, -- error messages on the command line


### PR DESCRIPTION
i dont know if we want to link related highlight groups to this new `Dimmed` group or keep the original `fg = C.overlay1`.
some hls this could work for:
- `NeoTreeDimText`
- `Conceal`
- `NeoTestIndent` (which should probably be using the same as `IblIndent` (suface0)
- `NeoTestExpandMarker`
- `SagaCount`
- `DropBarIconUISeparator`

https://github.com/neovim/neovim/pull/39505