### PR TITLE
feat(editor): add highlights for PmenuKind and PmenuKindSel

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -71,6 +71,11 @@ function M.get()
 		PmenuMatchSel = { style = { "bold" } }, -- Popup menu: matching text in selected item; is combined with |hl-PmenuMatch| and |hl-PmenuSel|.
 		PmenuSbar = { bg = C.surface0 }, -- Popup menu: scrollbar.
 		PmenuThumb = { bg = C.overlay0 }, -- Popup menu: Thumb of the scrollbar.
+		PmenuKind = {
+			bg = (O.transparent_background and vim.o.pumblend == 0) and C.none or C.mantle,
+			fg = C.blue,
+		}, -- Popup menu: item kind. Background and style must match `Pmenu`.
+		PmenuKindSel = { bg = C.surface0, fg = C.blue, style = { "bold" } }, -- Popup menu: selected item kind. Background and style must match `PmenuSel`.
 		PmenuExtra = { fg = C.overlay0 }, -- Popup menu: normal item extra text.
 		PmenuExtraSel = {
 			bg = C.surface0,


### PR DESCRIPTION
The default links to Pmenu and PmenuSel, which makes the kind text or symbol difficult to distinguish from the actual item.

Configured PmenuKind and PmenuKindSel to match Pmenu and PmenuSel in `bg` and `style`, but set `fg` to `blue` (same as for `blink.cmp` and `nvim-cmp`).

Before (kind symbols have same color as item):
<img width="450" height="261" alt="catppuccin-pmenukind-before" src="https://github.com/user-attachments/assets/74c6386f-29dd-4a47-9bde-dc3911804b71" />

After (kind symbols are blue to distinguish them from items):
<img width="450" height="261" alt="catppuccin-pmenukind-after" src="https://github.com/user-attachments/assets/c6d5422f-dc93-4da5-81d3-cbd1a7335278" />
