### PR TITLE
feat(csv): highlight escaped column

### DIFF
--- a/lua/catppuccin/groups/syntax.lua
+++ b/lua/catppuccin/groups/syntax.lua
@@ -109,6 +109,7 @@ function M.get()
 		csvCol6 = { fg = C.lavender },
 		csvCol7 = { fg = C.mauve },
 		csvCol8 = { fg = C.pink },
+		escCsvCol0 = { link = "csvCol0" },
 
 		-- markdown
 		markdownHeadingDelimiter = { fg = C.peach, style = { "bold" } },


### PR DESCRIPTION
Related: #720 

When using quotes to escape columns, the first column does not have any highlighting:

<img width="248" height="107" alt="image" src="https://github.com/user-attachments/assets/297af575-5bea-4e97-8c6c-f3b5ac1a215e" />

**After**:

<img width="196" height="93" alt="image" src="https://github.com/user-attachments/assets/4a0f3ec9-d2d3-4a9f-adc4-c313f7f07d19" />

This happens because upstream, in Vim, [there's no explicit definition for](https://github.com/vim/vim/blob/834b8d218f1db92e587ecd449e5ce88b41fbe256/runtime/syntax/csv.vim#L20-L38) `csvCol0`, and, therefore, no link between that and `escCsvCol0`. I assume that's intentional on Vim's side ([ref](https://github.com/vim/vim/issues/15038)) and warrants a fix here.