### PR TITLE
fix: pumsolid ternary to avoid runtime crash

### DIFF
--- a/lua/catppuccin/groups/editor.lua
+++ b/lua/catppuccin/groups/editor.lua
@@ -2,7 +2,9 @@ local M = {}
 
 function M.get()
 	local pumsolid = O.float.solid
-	if vim.fn.has "nvim-0.12" == 1 then pumsolid = vim.o.pumborder == "solid" end
+	if vim.fn.has "nvim-0.12" == 1 then
+		pumsolid = vim.o.pumborder and vim.o.pumborder == "solid" or false
+	end
 
 	return {
 		ColorColumn = { bg = C.surface0 }, -- used for the columns set with 'colorcolumn'


### PR DESCRIPTION
# Fixing pumsolid variable

When trying to set catppuccin colorscheme, I got the following error:

```txt
vim.schedule callback: vim/_editor.lua:447: nvim_exec2()[1]..C:\Users\pedro\AppData\Local\nvim-data\lazy\catppuccin\colors\catppuccin.lua: Vim(colorscheme):E5113: Lua chunk: ...im-data/lazy/catppuccin/lua/catppuccin/groups/editor.lua:5: Unknown option 'pumborder'
stack traceback:
	[C]: in function '__index'
	...im-data/lazy/catppuccin/lua/catppuccin/groups/editor.lua:5: in function 'get'
	.../nvim-data/lazy/catppuccin/lua/catppuccin/lib/mapper.lua:26: in function 'apply'
	...vim-data/lazy/catppuccin/lua/catppuccin/lib/compiler.lua:24: in function 'compile'
	.../Local/nvim-data/lazy/catppuccin/lua/catppuccin/init.lua:131: in function 'compile'
	.../Local/nvim-data/lazy/catppuccin/lua/catppuccin/init.lua:224: in function 'setup'
	.../Local/nvim-data/lazy/catppuccin/lua/catppuccin/init.lua:163: in function 'load'
	...ta/Local/nvim-data/lazy/catppuccin/colors/catppuccin.lua:1: in main chunk
	[C]: in function 'nvim_exec2'
	vim/_editor.lua:447: in function 'cmd'
	...nvim-data/lazy/snacks.nvim/lua/snacks/picker/preview.lua:362: in function <...nvim-data/lazy/snacks.nvim/lua/snacks/picker/preview.lua:361>
stack traceback:
	[C]: in function 'nvim_exec2'
	vim/_editor.lua:447: in function 'cmd'
	...nvim-data/lazy/snacks.nvim/lua/snacks/picker/preview.lua:362: in function <...nvim-data/lazy/snacks.nvim/lua/snacks/picker/preview.lua:361>
```

By checking the `editor.lua` file, we have this:
```lua
if vim.fn.has "nvim-0.12" == 1 then pumsolid = vim.o.pumborder == "solid" end
```

The error is raised when trying to get a value of an undefined identifier. This can be fixed by just turning the operation into a `if` block:

```lua
if vim.fn.has "nvim-0.12" == 1 then
        pumsolid = vim.o.pumborder and vim.o.pumborder == "solid" or false
end
```

## Species

My neovim species:
```txt
$ nvim -v
NVIM v0.12.0-dev-446+gc4e52d604c
Build type: RelWithDebInfo
LuaJIT 2.1.1744317938
```

I'm on `Windows 11 x64` machine btw...