### PR TITLE
fix(integrations): align documented defaults

### DIFF
--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -59,8 +59,10 @@ local M = {
 		auto_integrations = false,
 		integrations = {
 			alpha = true,
+			artio = true,
 			blink_cmp = { enabled = true, style = "bordered" },
 			blink_indent = true,
+			blink_pairs = true,
 			fzf = true,
 			cmp = true,
 			dap = true,


### PR DESCRIPTION
In `README.md`, the `blink_pairs` integration is documented as enabled by default, but it isn't actually included in the default `integrations` table in `init.lua`. I found that the `artio` integration also has the same problem.

This PR adds these two integrations to the defaults to match the `README.md` and avoid confusion.