### PR TITLE
fix!: remove `default_integrations`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,7 @@ require("catppuccin").setup({
     },
     color_overrides = {},
     custom_highlights = {},
-    default_integrations = true,
-    auto_integrations = false,
+    auto_integrations = true,
     integrations = {
         cmp = true,
         gitsigns = true,
@@ -295,15 +294,7 @@ require("catppuccin").setup({
 })
 ```
 
-Some integrations are enabled by default, you can control this behaviour with `default_integrations` option.
-
-```lua
-require("catppuccin").setup({
-    default_integrations = false,
-})
-```
-
-If you use [lazy.nvim](https://github.com/folke/lazy.nvim) as your package manager, you can use the `auto_integrations` option to let catppuccin automatically detect installed plugins and enable their respective integrations.
+If you use [lazy.nvim](https://github.com/folke/lazy.nvim) as your package manager, you can use the `auto_integrations` option to let catppuccin automatically detect installed plugins and enable their respective integrations (this option is enabled by default).
 
 ```lua
 require("catppuccin").setup({

--- a/README.md
+++ b/README.md
@@ -294,7 +294,11 @@ require("catppuccin").setup({
 })
 ```
 
-If you use `vim.pack` for managing your plugins, or if you [lazy.nvim](https://github.com/folke/lazy.nvim) or [pckr.nvim](https://github.com/lewis6991/pckr.nvim) as plugin managers, you can use the `auto_integrations` option to let catppuccin automatically detect installed plugins and enable their respective integrations (this option is enabled by default).
+If you use `vim.pack`, [lazy.nvim](https://github.com/folke/lazy.nvim) or
+[pckr.nvim](https://github.com/lewis6991/pckr.nvim) to manage your plugins, you
+can use the `auto_integrations` option to let catppuccin automatically detect
+installed plugins and enable their respective integrations (this option is
+enabled by default).
 
 ```lua
 require("catppuccin").setup({

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ require("catppuccin").setup({
 })
 ```
 
-If you use [lazy.nvim](https://github.com/folke/lazy.nvim) as your package manager, you can use the `auto_integrations` option to let catppuccin automatically detect installed plugins and enable their respective integrations (this option is enabled by default).
+If you use `vim.pack` for managing your plugins, or if you [lazy.nvim](https://github.com/folke/lazy.nvim) or [pckr.nvim](https://github.com/lewis6991/pckr.nvim) as plugin managers, you can use the `auto_integrations` option to let catppuccin automatically detect installed plugins and enable their respective integrations (this option is enabled by default).
 
 ```lua
 require("catppuccin").setup({

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -279,12 +279,11 @@ example:
     })
 <
 
-If you use `vim.pack` for managing your plugins, or if you lazy.nvim
-<https://github.com/folke/lazy.nvim> or pckr.nvim
-<https://github.com/lewis6991/pckr.nvim> as plugin managers, you can use the
-`auto_integrations` option to let catppuccin automatically detect installed
-plugins and enable their respective integrations (this option is enabled by
-default).
+If you use `vim.pack`, lazy.nvim <https://github.com/folke/lazy.nvim> or
+pckr.nvim <https://github.com/lewis6991/pckr.nvim> to manage your plugins, you
+can use the `auto_integrations` option to let catppuccin automatically detect
+installed plugins and enable their respective integrations (this option is
+enabled by default).
 
 >lua
     require("catppuccin").setup({

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -279,10 +279,12 @@ example:
     })
 <
 
-If you use lazy.nvim <https://github.com/folke/lazy.nvim> as your package
-manager, you can use the `auto_integrations` option to let catppuccin
-automatically detect installed plugins and enable their respective integrations
-(this option is enabled by default).
+If you use `vim.pack` for managing your plugins, or if you lazy.nvim
+<https://github.com/folke/lazy.nvim> or pckr.nvim
+<https://github.com/lewis6991/pckr.nvim> as plugin managers, you can use the
+`auto_integrations` option to let catppuccin automatically detect installed
+plugins and enable their respective integrations (this option is enabled by
+default).
 
 >lua
     require("catppuccin").setup({

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -1,4 +1,5 @@
 *catppuccin.txt*                              Soothing pastel theme for NeoVim
+                                For nvim >= 0.8.0    Last change: 2026 July 19
 
 ==============================================================================
 Table of Contents                               *catppuccin-table-of-contents*

--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -1,5 +1,4 @@
 *catppuccin.txt*                              Soothing pastel theme for NeoVim
-                                For nvim >= 0.8.0    Last change: 2026 June 21
 
 ==============================================================================
 Table of Contents                               *catppuccin-table-of-contents*
@@ -144,8 +143,7 @@ options and settings.
         },
         color_overrides = {},
         custom_highlights = {},
-        default_integrations = true,
-        auto_integrations = false,
+        auto_integrations = true,
         integrations = {
             cmp = true,
             gitsigns = true,
@@ -280,19 +278,10 @@ example:
     })
 <
 
-Some integrations are enabled by default, you can control this behaviour with
-`default_integrations` option.
-
->lua
-    require("catppuccin").setup({
-        default_integrations = false,
-    })
-<
-
 If you use lazy.nvim <https://github.com/folke/lazy.nvim> as your package
 manager, you can use the `auto_integrations` option to let catppuccin
-automatically detect installed plugins and enable their respective
-integrations.
+automatically detect installed plugins and enable their respective integrations
+(this option is enabled by default).
 
 >lua
     require("catppuccin").setup({

--- a/lua/catppuccin/groups/integrations/artio.lua
+++ b/lua/catppuccin/groups/integrations/artio.lua
@@ -3,7 +3,7 @@ local M = {}
 M.url = "https://github.com/comfysage/artio.nvim"
 
 function M.get()
-	local transparent_background = require("catppuccin").options.transparent_background
+	local transparent_background = O.transparent_background
 
 	return {
 		ArtioNormal = {

--- a/lua/catppuccin/groups/integrations/colorful_winsep.lua
+++ b/lua/catppuccin/groups/integrations/colorful_winsep.lua
@@ -3,9 +3,11 @@ local M = {}
 M.url = "https://github.com/nvim-zh/colorful-winsep.nvim"
 
 function M.get()
+	local color = U.select_color(O.integrations.colorful_winsep.color, "red")
+
 	return {
 		ColorfulWinSep = {
-			fg = C[O.integrations.colorful_winsep.color],
+			fg = color,
 			bg = O.transparent_background and C.none or C.base,
 		},
 		NvimSeparator = { link = "ColorfulWinSep" },

--- a/lua/catppuccin/groups/integrations/gitsigns.lua
+++ b/lua/catppuccin/groups/integrations/gitsigns.lua
@@ -3,9 +3,7 @@ local M = {}
 M.url = "https://github.com/lewis6991/gitsigns.nvim"
 
 function M.get()
-	-- (a ~= nil) and a or b: Potential false-negative handling
-	local transparent = O.transparent_background
-	if type(O.integrations.gitsigns.transparent) == "boolean" then transparent = O.integrations.gitsigns.transparent end
+	local transparent = U.nonnil(O.integrations.gitsigns.transparent, O.transparent_background)
 
 	if transparent then
 		return {

--- a/lua/catppuccin/groups/integrations/indent_blankline.lua
+++ b/lua/catppuccin/groups/integrations/indent_blankline.lua
@@ -3,11 +3,11 @@ local M = {}
 M.url = "https://github.com/lukas-reineke/indent-blankline.nvim"
 
 function M.get()
-	local scope_color = O.integrations.indent_blankline.scope_color
+	local scope_color = U.select_color(O.integrations.indent_blankline.scope_color, "overlay2")
 
 	local hi = {
 		IblIndent = { fg = C.surface0 },
-		IblScope = { fg = C[scope_color] or C.text },
+		IblScope = { fg = scope_color },
 	}
 
 	if O.integrations.indent_blankline.colored_indent_levels then

--- a/lua/catppuccin/groups/integrations/mini.lua
+++ b/lua/catppuccin/groups/integrations/mini.lua
@@ -3,12 +3,12 @@ local M = {}
 M.url = "https://github.com/echasnovski/mini.nvim"
 
 function M.get()
-	local transparent_background = require("catppuccin").options.transparent_background
+	local transparent_background = O.transparent_background
 	local bg_highlight = transparent_background and "NONE" or C.base
 
 	local inactive_bg = transparent_background and "NONE" or C.mantle
 
-	local indentscope_color = O.integrations.mini.indentscope_color
+	local indentscope_color = U.select_color(O.integrations.mini.indentscope_color, "overlay2")
 	return {
 		MiniAnimateCursor = { style = { "reverse", "nocombine" } },
 		MiniAnimateNormalFloat = { link = "NormalFloat" },
@@ -76,7 +76,7 @@ function M.get()
 		MiniIconsRed = { fg = C.red },
 		MiniIconsYellow = { fg = C.yellow },
 
-		MiniIndentscopeSymbol = { fg = C[indentscope_color] or C.overlay2 },
+		MiniIndentscopeSymbol = { fg = indentscope_color },
 
 		MiniJump = { fg = C.overlay2, bg = C.pink },
 

--- a/lua/catppuccin/groups/integrations/navic.lua
+++ b/lua/catppuccin/groups/integrations/navic.lua
@@ -3,8 +3,11 @@ local M = {}
 M.url = "https://github.com/SmiteshP/nvim-navic"
 
 function M.get()
-	local background = O.integrations.navic.custom_bg and O.integrations.navic.custom_bg or C.none
+	local background = O.integrations.navic.custom_bg or C.none
 	if O.integrations.navic.custom_bg == "lualine" then background = C.mantle end
+	if background ~= C.none and string.sub(background, 0, 1) ~= "#" then
+		background = U.select_color(background, "none")
+	end
 
 	return {
 		NavicIconsFile = { fg = C.blue, bg = background },

--- a/lua/catppuccin/groups/integrations/snacks.lua
+++ b/lua/catppuccin/groups/integrations/snacks.lua
@@ -3,7 +3,7 @@ local M = {}
 M.url = "https://github.com/folke/snacks.nvim"
 
 function M.get()
-	local indent_scope_color = O.integrations.snacks.indent_scope_color
+	local indent_scope_color = U.select_color(O.integrations.snacks.indent_scope_color, "overlay2")
 
 	local hlgroups = {
 		SnacksNormal = { link = "Normal" },
@@ -51,7 +51,7 @@ function M.get()
 		SnacksDashboardTitle = { link = "Title" },
 
 		SnacksIndent = { fg = C.surface0 },
-		SnacksIndentScope = { fg = C[indent_scope_color] or C.overlay2 },
+		SnacksIndentScope = { fg = indent_scope_color },
 
 		SnacksPickerSelected = {
 			fg = O.float.transparent and C.flamingo or C.text,

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -55,66 +55,8 @@ local M = {
 				background = true,
 			},
 		},
-		default_integrations = true,
-		auto_integrations = false,
-		integrations = {
-			alpha = true,
-			blink_cmp = { enabled = true, style = "bordered" },
-			blink_indent = true,
-			fzf = true,
-			cmp = true,
-			dap = true,
-			dap_ui = true,
-			dashboard = true,
-			diffview = false,
-			flash = true,
-			gitsigns = true,
-			markdown = true,
-			neogit = true,
-			neotree = true,
-			nvimtree = true,
-			ufo = true,
-			rainbow_delimiters = true,
-			render_markdown = true,
-			telescope = { enabled = true },
-			treesitter_context = true,
-			barbecue = {
-				dim_dirname = true,
-				bold_basename = true,
-				dim_context = false,
-				alt_background = false,
-			},
-			illuminate = {
-				enabled = true,
-				lsp = false,
-			},
-			indent_blankline = {
-				enabled = true,
-				scope_color = "",
-				colored_indent_levels = false,
-			},
-			navic = {
-				enabled = false,
-				custom_bg = "NONE",
-			},
-			dropbar = {
-				enabled = true,
-				color_mode = false,
-			},
-			colorful_winsep = {
-				enabled = false,
-				color = "red",
-			},
-			mini = {
-				enabled = true,
-				indentscope_color = "overlay2",
-			},
-			lir = {
-				enabled = false,
-				git_status = false,
-			},
-			snacks = { enabled = false },
-		},
+		auto_integrations = true,
+		integrations = {},
 		color_overrides = {},
 		highlight_overrides = {},
 	},
@@ -183,20 +125,6 @@ function M.setup(user_conf)
 			require("catppuccin.lib.detect_integrations").create_integrations_table(),
 			user_conf.integrations or {}
 		)
-	end
-
-	if user_conf.default_integrations == false then M.default_options.integrations = {} end
-	if user_conf.default_integrations == false then
-		M.default_options.integrations = vim.iter(pairs(M.default_options.integrations))
-			:fold({}, function(integrations, name, opts)
-				if type(opts) == "table" then
-					opts.enabled = false
-				else
-					opts = false
-				end
-				integrations[name] = opts
-				return integrations
-			end)
 	end
 
 	M.options = vim.tbl_deep_extend("keep", user_conf, M.default_options)

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -56,7 +56,37 @@ local M = {
 			},
 		},
 		auto_integrations = true,
-		integrations = {},
+		integrations = {
+			blink_cmp = { style = "bordered" },
+			barbecue = {
+				dim_dirname = true,
+				bold_basename = true,
+				dim_context = false,
+				alt_background = false,
+			},
+			illuminate = {
+				lsp = false,
+			},
+			indent_blankline = {
+				scope_color = "",
+				colored_indent_levels = false,
+			},
+			navic = {
+				custom_bg = "NONE",
+			},
+			dropbar = {
+				color_mode = false,
+			},
+			colorful_winsep = {
+				color = "red",
+			},
+			mini = {
+				indentscope_color = "overlay2",
+			},
+			lir = {
+				git_status = false,
+			},
+		},
 		color_overrides = {},
 		highlight_overrides = {},
 	},

--- a/lua/catppuccin/types.lua
+++ b/lua/catppuccin/types.lua
@@ -32,8 +32,6 @@
 ---@field styles CtpStyles?
 -- Handles the style of specific lsp hl groups (see `:h lsp-highlight`).
 ---@field lsp_styles CtpLspStyles?
--- Should default integrations be used.
----@field default_integrations boolean?
 -- Should detect integrations automatically
 ---@field auto_integrations boolean?
 -- Toggle integrations. Integrations allow Catppuccin to set the theme of various plugins.
@@ -224,7 +222,7 @@
 ---@field signify boolean?
 ---@field symbols_outline boolean?
 ---@field telekasten boolean?
----@field telescope CtpIntegrationTelescope | boolean?
+---@field telescope boolean?
 ---@field treesitter_context boolean?
 ---@field ts_rainbow boolean?
 ---@field ts_rainbow2 boolean?
@@ -315,10 +313,6 @@
 ---@field enabled boolean
 -- Sets the color of the indent scope line
 ---@field indent_scope_color CtpColor?
-
----@class CtpIntegrationTelescope
--- Whether to enable the telescope integration
----@field enabled boolean?
 
 ---@class CtpIntegrationIlluminate
 -- Whether to enable the vim-illuminate integration

--- a/lua/catppuccin/utils/colors.lua
+++ b/lua/catppuccin/utils/colors.lua
@@ -106,23 +106,21 @@ function M.vary_color(palettes, default)
 	return default
 end
 
-M.nonnil = vim.nonnil or vim.F.if_nil or function(...)
-  local nargs = select('#', ...)
-  for i = 1, nargs do
-    local v = select(i, ...)
-    if v ~= nil then
-      return v
-    end
-  end
-  return nil
-end
+M.nonnil = vim.nonnil
+	or vim.F.if_nil
+	or function(...)
+		local nargs = select("#", ...)
+		for i = 1, nargs do
+			local v = select(i, ...)
+			if v ~= nil then return v end
+		end
+		return nil
+	end
 
 ---@param color (Color|string)?
 ---@param default Color
 ---@return string
-function M.select_color(color, default)
-	return C[M.nonnil(color, default)] or C[default]
-end
+function M.select_color(color, default) return C[M.nonnil(color, default)] or C[default] end
 
 local function rgb2Hex(rgb)
 	local hexadecimal = "#"

--- a/lua/catppuccin/utils/colors.lua
+++ b/lua/catppuccin/utils/colors.lua
@@ -106,6 +106,24 @@ function M.vary_color(palettes, default)
 	return default
 end
 
+M.nonnil = vim.nonnil or vim.F.if_nil or function(...)
+  local nargs = select('#', ...)
+  for i = 1, nargs do
+    local v = select(i, ...)
+    if v ~= nil then
+      return v
+    end
+  end
+  return nil
+end
+
+---@param color (Color|string)?
+---@param default Color
+---@return string
+function M.select_color(color, default)
+	return C[M.nonnil(color, default)] or C[default]
+end
+
 local function rgb2Hex(rgb)
 	local hexadecimal = "#"
 


### PR DESCRIPTION
fix #1018 

additional changes:
- feat: enable `auto_integrations` by default
- fix(integrations): options can be nil
- fix(integrations): use `O` over `require("catppuccin").options`
- fix(colorful_winsep): color option can be invalid
- fix(gitsigns): option logic
- fix(indent_blankline): do not index table with nil
- fix(mini): color option can be invalid
- fix(navic): do not use `CtpColor` for color fields
- fix(snacks): color option can be invalid
- fix(telescope): make integration options a boolean this was a table even though it didnt have any options
