### PR TITLE
fix(integrations): auto_integrations not created if not set by user

### DIFF
--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -149,16 +149,16 @@ function M.setup(user_conf)
 	-- Parsing user config
 	user_conf = user_conf or {}
 
-	if user_conf.auto_integrations == true then
-		user_conf.integrations = vim.tbl_deep_extend(
+	M.options = vim.tbl_deep_extend("keep", user_conf, M.default_options)
+	M.options.highlight_overrides.all = user_conf.custom_highlights or M.options.highlight_overrides.all
+
+	if M.options.auto_integrations == true then
+		M.options.integrations = vim.tbl_deep_extend(
 			"force",
 			require("catppuccin.lib.detect_integrations").create_integrations_table(),
 			user_conf.integrations or {}
 		)
 	end
-
-	M.options = vim.tbl_deep_extend("keep", user_conf, M.default_options)
-	M.options.highlight_overrides.all = user_conf.custom_highlights or M.options.highlight_overrides.all
 
 	-- Get cached hash
 	local cached_path = M.options.compile_path .. M.path_sep .. "cached"

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -156,7 +156,7 @@ function M.setup(user_conf)
 		M.options.integrations = vim.tbl_deep_extend(
 			"force",
 			require("catppuccin.lib.detect_integrations").create_integrations_table(),
-			user_conf.integrations or {}
+			M.options.integrations or {}
 		)
 	end
 


### PR DESCRIPTION
After #1019 enabled `auto_integrations` by default, the actual code path to check `auto_integrations` was still using the user supplied setup options. This meant that unless explicitly set to `true` by the user, the `auto_integrations` are effectively still false.
Moved the check to after merging with the default options.

I checked this on my system and it works but I don't have a ton of custom options set so I'm not entirely sure this is the exact correct call.