### PR TITLE
fix: check if `auto_integrations` was explicitly disabled

### DIFF
--- a/doc/catppuccin.txt
+++ b/doc/catppuccin.txt
@@ -1,5 +1,5 @@
 *catppuccin.txt*                              Soothing pastel theme for NeoVim
-                                For nvim >= 0.8.0    Last change: 2026 July 19
+                                For nvim >= 0.8.0    Last change: 2026 July 22
 
 ==============================================================================
 Table of Contents                               *catppuccin-table-of-contents*

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -149,7 +149,7 @@ function M.setup(user_conf)
 	-- Parsing user config
 	user_conf = user_conf or {}
 
-	if user_conf.auto_integrations == true then
+	if user_conf.auto_integrations ~= false then
 		user_conf.integrations = vim.tbl_deep_extend(
 			"force",
 			require("catppuccin.lib.detect_integrations").create_integrations_table(),

--- a/lua/catppuccin/init.lua
+++ b/lua/catppuccin/init.lua
@@ -149,16 +149,17 @@ function M.setup(user_conf)
 	-- Parsing user config
 	user_conf = user_conf or {}
 
-	if user_conf.auto_integrations ~= false then
-		user_conf.integrations = vim.tbl_deep_extend(
+	M.options = vim.tbl_deep_extend("keep", user_conf, M.default_options)
+
+	if M.options.auto_integrations then
+		M.options.integrations = vim.tbl_deep_extend(
 			"force",
 			require("catppuccin.lib.detect_integrations").create_integrations_table(),
-			user_conf.integrations or {}
+			M.options.integrations or {}
 		)
 	end
 
-	M.options = vim.tbl_deep_extend("keep", user_conf, M.default_options)
-	M.options.highlight_overrides.all = user_conf.custom_highlights or M.options.highlight_overrides.all
+	M.options.highlight_overrides.all = M.options.custom_highlights or M.options.highlight_overrides.all
 
 	-- Get cached hash
 	local cached_path = M.options.compile_path .. M.path_sep .. "cached"


### PR DESCRIPTION
`auto_integrations` is enabled by default now which means that simply checking if the user enabled the option does not work. Instead, we should check if `auto_integrations == false`.